### PR TITLE
Fix Go's reliance of $HOME

### DIFF
--- a/dockerfiles/go-1.22.Dockerfile
+++ b/dockerfiles/go-1.22.Dockerfile
@@ -2,6 +2,11 @@ FROM golang:1.22-alpine
 
 ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="go.mod,go.sum"
 
+# By default, Go uses $HOME for GOCACHE. We need to override $HOME in some tests,
+# so let's ensure Go uses a different directory for caching.
+RUN mkdir -p /cache
+ENV GOCACHE=/cache
+
 WORKDIR /app
 
 COPY go.mod go.sum ./


### PR DESCRIPTION
We mutate $HOME in some stages, and Go uses this as the default cache location. I've changed the tester to test this intentionally in stage 1 by using a random dir for $HOME there. 

Go tests fail without the changes where we set `GOCACHE`. For all new languages, this should help catch these issues early. 