### PR TITLE
CC-1291: add Go to all build image dockerfiles

### DIFF
--- a/dockerfiles/bun-1.1.Dockerfile
+++ b/dockerfiles/bun-1.1.Dockerfile
@@ -1,5 +1,8 @@
 FROM oven/bun:1.1.4-alpine
 
+# We need to install Go to build the custom executable.
+RUN apk add --no-cache "go>=1.20"
+
 ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="package.json,bun.lockb"
 
 WORKDIR /app

--- a/dockerfiles/c-9.2.Dockerfile
+++ b/dockerfiles/c-9.2.Dockerfile
@@ -1,1 +1,4 @@
 FROM n0madic/alpine-gcc:9.2.0
+
+# We need to install Go to build the custom executable.
+RUN apk add --no-cache "go>=1.20"

--- a/dockerfiles/c-9.2.Dockerfile
+++ b/dockerfiles/c-9.2.Dockerfile
@@ -1,4 +1,4 @@
 FROM n0madic/alpine-gcc:9.2.0
 
 # We need to install Go to build the custom executable.
-RUN apk add --no-cache "go>=1.20"
+RUN apk add --no-cache "go>=1.12"

--- a/dockerfiles/cpp-23.Dockerfile
+++ b/dockerfiles/cpp-23.Dockerfile
@@ -3,7 +3,9 @@ FROM gcc:13.2.0-bookworm
 
 ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="vcpkg.json,vcpkg-configuration.json"
 
+# We need to install Go to build the custom executable.
 RUN apt-get update && \
+    apt-get install -y --no-install-recommends golang-go=2:* && \
     apt-get install --no-install-recommends -y zip=3.* && \ 
     apt-get install --no-install-recommends -y g++=4:* && \
     apt-get install --no-install-recommends -y build-essential=12.* && \

--- a/dockerfiles/java-21.Dockerfile
+++ b/dockerfiles/java-21.Dockerfile
@@ -1,5 +1,8 @@
 FROM maven:3.9.5-eclipse-temurin-21-alpine
 
+# We need to install Go to build the custom executable.
+RUN apk add --no-cache "go>=1.20"
+
 COPY pom.xml /app/pom.xml
 
 WORKDIR /app

--- a/dockerfiles/nodejs-21.Dockerfile
+++ b/dockerfiles/nodejs-21.Dockerfile
@@ -1,5 +1,8 @@
 FROM node:21.7-alpine3.19
 
+# We need to install Go to build the custom executable.
+RUN apk add --no-cache "go>=1.20"
+
 ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="package.json,package-lock.json"
 
 WORKDIR /app

--- a/dockerfiles/python-3.12.Dockerfile
+++ b/dockerfiles/python-3.12.Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.12-alpine
 
+# We need to install Go to build the custom executable.
 RUN apk add --no-cache "go>=1.20"
 
 RUN pip install --no-cache-dir "pipenv>=2023.12.1"

--- a/dockerfiles/rust-1.77.Dockerfile
+++ b/dockerfiles/rust-1.77.Dockerfile
@@ -1,5 +1,6 @@
 FROM rust:1.77-buster
 
+# We need to install Go to build the custom executable.
 RUN apt-get update && apt-get install -y --no-install-recommends golang-go=2:* && rm -rf /var/lib/apt/lists/*
 
 COPY Cargo.toml /app/Cargo.toml


### PR DESCRIPTION
Go is required for creating the custom executable used in shell tests. Missing the go install would prohibit us from running shell tests.