### PR TITLE
CC-1330: Update C Docker image to fix cgo warnings

### DIFF
--- a/dockerfiles/c-9.2.Dockerfile
+++ b/dockerfiles/c-9.2.Dockerfile
@@ -1,4 +1,8 @@
-FROM n0madic/alpine-gcc:9.2.0
+FROM alpine:3.19
+
+RUN apk update && \
+    apk add --no-cache "gcc>=13" && \
+    apk add --no-cache "musl-dev>=1.2"
 
 # We need to install Go to build the custom executable.
-RUN apk add --no-cache "go>=1.12"
+RUN apk add --no-cache "go>=1.21"


### PR DESCRIPTION
This pull request updates the C Docker image to use the base Alpine image instead of the previous image. This change fixes persistent CGO warnings that were present in the previous image. The new image uses Alpine version 3.19 and includes updates to the GCC and Musl-dev packages. Additionally, the Go version has been updated to 1.21.