### PR TITLE
CC-1291: Add CI workflow to check Go presence in all language buildpacks

### DIFF
--- a/.github/workflows/check-go-is-present.yml
+++ b/.github/workflows/check-go-is-present.yml
@@ -1,4 +1,4 @@
-name: Check Go
+name: Check Go is present inside all language buildpacks
 
 on:
   pull_request:
@@ -11,6 +11,6 @@ concurrency:
 
 jobs:
   test_course_definition:
-    uses: codecrafters-io/course-sdk/.github/workflows/check-go-is-present.yml@CC-1291
+    uses: codecrafters-io/course-sdk/.github/workflows/check-go-is-present.yml@main
     with:
-      sdkRef: CC-1291
+      sdkRef: main

--- a/.github/workflows/check-go.yml
+++ b/.github/workflows/check-go.yml
@@ -12,3 +12,5 @@ concurrency:
 jobs:
   test_course_definition:
     uses: codecrafters-io/course-sdk/.github/workflows/check-go.yml@CC-1291
+    with:
+      sdkRef: CC-1291

--- a/.github/workflows/check-go.yml
+++ b/.github/workflows/check-go.yml
@@ -11,6 +11,6 @@ concurrency:
 
 jobs:
   test_course_definition:
-    uses: codecrafters-io/course-sdk/.github/workflows/check-go.yml@CC-1291
+    uses: codecrafters-io/course-sdk/.github/workflows/check-go-is-present.yml@CC-1291
     with:
       sdkRef: CC-1291

--- a/.github/workflows/check-go.yml
+++ b/.github/workflows/check-go.yml
@@ -1,0 +1,14 @@
+name: Check Go
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test_course_definition:
+    uses: codecrafters-io/course-sdk/.github/workflows/check-go.yml@CC-1291


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow for checking the Go runtime. The workflow is triggered on pull requests and pushes to the main branch. It includes a job that tests the course definition using the codecrafters-io/course-sdk repository. The workflow is designed to run concurrently and can cancel in-progress jobs.