### PR TITLE
Update spacing in redirection stages in shell course

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -765,8 +765,10 @@ stages:
     difficulty: medium
     description_md: |-
       In this stage, you'll implement support for redirecting the output of a command to a file.
+
       The `1>` operator is used to redirect the output of a command to a file.
       But, as a special case, if the file descriptor is not specified before the operator `>`, the output is redirected to the standard output by default, so `>` is equivalent to `1>`.
+
       Learn more about [Redirecting Output](https://www.gnu.org/software/bash/manual/bash.html#Redirecting-Output).
 
       ### Tests
@@ -805,7 +807,9 @@ stages:
     difficulty: medium
     description_md: |-
       In this stage, you'll implement support for redirecting the standard error of a command to a file.
+
       The `2>` operator is used to redirect the standard error of a command to a file.
+
       Learn more about [Redirecting Stderr](https://www.gnu.org/software/bash/manual/bash.html#Redirecting-Output).
 
       ### Tests
@@ -842,8 +846,10 @@ stages:
     difficulty: medium
     description_md: |-
       In this stage, you'll implement support for appending the output of a command to a file.
+
       The `1>>` operator is used to append the output of a command to a file.
       As a special case, if the file descriptor is not specified before the operator `>>`, the output is redirected to the standard output by default, so `>>` is equivalent to `1>>`.
+
       Learn more about [Appending Stdout](https://www.gnu.org/software/bash/manual/bash.html#Appending-Redirected-Output).
 
       ### Tests
@@ -888,7 +894,9 @@ stages:
     difficulty: medium
     description_md: |-
       In this stage, you'll implement support for appending the standard error of a command to a file.
+
       The `2>>` operator is used to append the standard error of a command to a file.
+
       Learn more about [Appending Stderr](https://www.gnu.org/software/bash/manual/bash.html#Appending-Redirected-Output).
 
       ### Tests


### PR DESCRIPTION
This pull request updates the spacing in the redirection stages of the shell course. It ensures consistent and proper spacing in the code examples and explanations for redirecting output, redirecting stderr, appending stdout, and appending stderr. These changes improve the readability and clarity of the course material.