### PR TITLE
[#qm8] Change bell char from `\a` to `\x07`

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -980,7 +980,7 @@ stages:
       The tester checks if the completion works as expected and if your shell outputs the correct output for `echo` and `exit` command.
       Note the space at the end of the completion.
 
-      ### Notes:
+      ### Notes
 
       - We recommend using a library like [readline](https://en.wikipedia.org/wiki/GNU_Readline) for your implementation. Most modern shells and REPLs (like the Python REPL) use readline under the hood. While you may need to override some of its default behaviors, it's typically less work than starting from scratch.
       - Different shells handle autocompletion differently. For consistency, we recommend using [Bash](https://www.gnu.org/software/bash/) for development and testing.
@@ -1048,7 +1048,7 @@ stages:
       The tester will verify that your shell does not attempt completion on invalid commands, the bell is sent.
       The bell is sent by printing the `\a` character.
 
-      ### Notes:
+      ### Notes
 
       - If `\a` is not supported in the language you're using, you can use `\u0007` instead.
 

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -1046,11 +1046,7 @@ stages:
           *   The tester will first type `xyz` and then press `<TAB>`. The tester expects that the prompt still shows "xyz" and there is a bell sound.
 
       The tester will verify that your shell does not attempt completion on invalid commands, the bell is sent.
-      The bell is sent by printing the `\a` character.
-
-      ### Notes
-
-      - If `\a` is not supported in the language you're using, you can use `\u0007` instead.
+      The bell is sent by printing `\x07`, the [bell character](https://en.wikipedia.org/wiki/Bell_character).
 
     marketing_md: |-
       In this stage, you'll implement support for handling invalid commands gracefully.

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -1048,6 +1048,10 @@ stages:
       The tester will verify that your shell does not attempt completion on invalid commands, the bell is sent.
       The bell is sent by printing the `\a` character.
 
+      ### Notes:
+
+      - If `\a` is not supported in the language you're using, you can use `\u0007` instead.
+
     marketing_md: |-
       In this stage, you'll implement support for handling invalid commands gracefully.
 


### PR DESCRIPTION
Multiple users have highlighted that \a does not work in Java, JS and TS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the course description to clarify alternatives for producing the bell sound in the "Missing completions" stage.  
  - Improved formatting by removing trailing colons from "Notes" section headers in two course stages.  
  - Added a link to the bell character Wikipedia page for additional reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->