### PR TITLE
[Shell] CC-1758: Upgrade Rust to v1.87

### DIFF
--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -27,7 +27,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.86)` installed locally
+1. Ensure you have `cargo (1.87)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/compiled_starters/rust/codecrafters.yml
+++ b/compiled_starters/rust/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.86
-language_pack: rust-1.86
+# Available versions: rust-1.87
+language_pack: rust-1.87

--- a/dockerfiles/rust-1.87.Dockerfile
+++ b/dockerfiles/rust-1.87.Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM rust:1.87-bookworm
+
+# Rebuild the container if these files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Cargo.toml,Cargo.lock"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs cargo build
+RUN .codecrafters/compile.sh

--- a/solutions/rust/01-oo8/code/README.md
+++ b/solutions/rust/01-oo8/code/README.md
@@ -27,7 +27,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.86)` installed locally
+1. Ensure you have `cargo (1.87)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/01-oo8/code/codecrafters.yml
+++ b/solutions/rust/01-oo8/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.86
-language_pack: rust-1.86
+# Available versions: rust-1.87
+language_pack: rust-1.87

--- a/solutions/rust/02-cz2/code/README.md
+++ b/solutions/rust/02-cz2/code/README.md
@@ -27,7 +27,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.86)` installed locally
+1. Ensure you have `cargo (1.87)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/02-cz2/code/codecrafters.yml
+++ b/solutions/rust/02-cz2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.86
-language_pack: rust-1.86
+# Available versions: rust-1.87
+language_pack: rust-1.87

--- a/starter_templates/rust/config.yml
+++ b/starter_templates/rust/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: cargo (1.86)
+  required_executable: cargo (1.87)
   user_editable_file: src/main.rs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated documentation and configuration files to require Rust version 1.87 instead of 1.86.
  - Added a new Dockerfile to support the Rust 1.87 environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->