### PR TITLE
Use non-breaking spaces for examples table

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -648,6 +648,12 @@ stages:
 
       The tester will check if the `cat` command correctly prints the file content.
 
+      Here are a few examples illustrating how backslashes behave within double quotes:
+      | Command | Expected output |
+      | :---: | :-------------: | 
+      | `echo "A \\ escapes itself"` | `A \ escapes itself` | 
+      | `echo "A \" inside double quotes"` | `A " inside double quotes` |
+
     marketing_md: |-
       In this stage, you'll implement support for quoting with double quotes.
 

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -598,8 +598,8 @@ stages:
 
       | Command | Expected output | Explanation |
       | :---: | :-------------: | :---------: |
-      | `echo 'hello     world'` | `hello     world` | Spaces are preserved within quotes. |
-      | `echo hello     world` | `hello world` | Consecutive spaces are collapsed unless quoted. |
+      | `echo 'hello&nbsp;&nbsp;&nbsp;&nbsp;world'` | `hello&nbsp;&nbsp;&nbsp;&nbsp;world` | Spaces are preserved within quotes. |
+      | `echo hello&nbsp;&nbsp;&nbsp;&nbsp;world` | `hello world` | Consecutive spaces are collapsed unless quoted. |
       | `echo 'hello''world'` | `helloworld` | Adjacent quoted strings are concatenated. ]
       | `echo hello''world` | `helloworld` | Empty quotes are ignored. ]
 


### PR DESCRIPTION
Revise examples to use HTML non-breaking spaces for clarity in command outputs. This change ensures that the instructional content accurately reflects the behavior of spaces in quoted strings, enhancing user understanding.