### PR TITLE
Update command completion examples in course-definition.yml

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -1057,11 +1057,11 @@ stages:
 
       The tests will simulate user input with tab presses and will execute builtin commands, similar to the previous stage, with added arguments:
 
-      1.  **Input:** `ech``<TAB>` `hello``<ENTER>`
+      1.  **Input:** `ech<TAB>` `hello<ENTER>`
           *   The tester expects the shell to first complete the `ech` to `echo` after `<TAB>`, then accept the `hello` argument, and after the `<ENTER>` key press, execute `echo hello`.
           *   The shell should output `hello`.
 
-      2.  **Input:** `exi``<TAB>` `type``<ENTER>`
+      2.  **Input:** `exi<TAB>` `0<ENTER>`
            *   The tester expects the shell to first complete `exi` to `exit` after `<TAB>`, then accept the `0` argument, and after the `<ENTER>` key press, execute `exit 0`.
            *   The shell should exit with status code 0.
 


### PR DESCRIPTION
Correct the input format for command completion examples, ensuring clarity in user interactions with the shell. The `echo` command example has been adjusted for proper syntax, and the `type` command has been replaced with `exit` to accurately reflect expected behavior during execution.