### PR TITLE
CC-1960 [Shell] Upgrade gcc to 14.3.0-bookworm

### DIFF
--- a/compiled_starters/c/.codecrafters/run.sh
+++ b/compiled_starters/c/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec $(dirname $0)/build/shell "$@"
+exec $(dirname "$0")/build/shell "$@"

--- a/compiled_starters/c/your_program.sh
+++ b/compiled_starters/c/your_program.sh
@@ -22,4 +22,4 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec $(dirname $0)/build/shell "$@"
+exec $(dirname "$0")/build/shell "$@"

--- a/compiled_starters/cpp/.codecrafters/compile.sh
+++ b/compiled_starters/cpp/.codecrafters/compile.sh
@@ -1,13 +1,12 @@
 #!/bin/sh
 #
 # This script is used to compile your program on CodeCrafters
-# 
+#
 # This runs before .codecrafters/run.sh
 #
 # Learn more: https://codecrafters.io/program-interface
 
-# Exit early if any commands fail
-set -e
+set -e # Exit on failure
 
 cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake
 cmake --build ./build

--- a/compiled_starters/cpp/.codecrafters/run.sh
+++ b/compiled_starters/cpp/.codecrafters/run.sh
@@ -1,12 +1,11 @@
 #!/bin/sh
 #
 # This script is used to run your program on CodeCrafters
-# 
+#
 # This runs after .codecrafters/compile.sh
 #
 # Learn more: https://codecrafters.io/program-interface
 
-# Exit early if any commands fail
-set -e
+set -e # Exit on failure
 
-exec ./build/shell "$@"
+exec $(dirname "$0")/build/shell "$@"

--- a/compiled_starters/cpp/your_program.sh
+++ b/compiled_starters/cpp/your_program.sh
@@ -22,4 +22,4 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec ./build/shell "$@"
+exec $(dirname "$0")/build/shell "$@"

--- a/dockerfiles/c-23.Dockerfile
+++ b/dockerfiles/c-23.Dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1.7-labs
-FROM gcc:14.2.0-bookworm
+FROM gcc:14.3.0-bookworm
 
 # Ensures the container is re-built if dependency files change
-ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="vcpkg.json,vcpkg-configuration.json"
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="CMakeLists.txt,vcpkg.json,vcpkg-configuration.json"
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y zip=3.* && \ 

--- a/dockerfiles/cpp-23.Dockerfile
+++ b/dockerfiles/cpp-23.Dockerfile
@@ -1,21 +1,20 @@
 # syntax=docker/dockerfile:1.7-labs
-FROM gcc:13.2.0-bookworm
+FROM gcc:14.3.0-bookworm
 
-ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="vcpkg.json,vcpkg-configuration.json"
+# Ensures the container is re-built if dependency files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="CMakeLists.txt,vcpkg.json,vcpkg-configuration.json"
 
-# We need to install Go to build the custom executable.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends golang-go=2:* && \
     apt-get install --no-install-recommends -y zip=3.* && \ 
     apt-get install --no-install-recommends -y g++=4:* && \
     apt-get install --no-install-recommends -y build-essential=12.* && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# cmake 3.29.2 is required by vcpkg
-RUN wget --progress=dot:giga https://github.com/Kitware/CMake/releases/download/v3.29.2/cmake-3.29.2-Linux-x86_64.tar.gz && \
-    tar -xzvf cmake-3.29.2-Linux-x86_64.tar.gz && \
-    mv cmake-3.29.2-linux-x86_64/ /cmake
+# cmake is required by vcpkg
+RUN wget --progress=dot:giga https://github.com/Kitware/CMake/releases/download/v3.30.5/cmake-3.30.5-Linux-x86_64.tar.gz && \
+    tar -xzvf cmake-3.30.5-Linux-x86_64.tar.gz && \
+    mv cmake-3.30.5-linux-x86_64/ /cmake
 
 ENV CMAKE_BIN="/cmake/bin"
 ENV PATH="${CMAKE_BIN}:$PATH"
@@ -34,9 +33,7 @@ COPY --exclude=.git --exclude=README.md . /app
 RUN vcpkg install --no-print-usage
 RUN sed -i '1s/^/set(VCPKG_INSTALL_OPTIONS --no-print-usage)\n/' ${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake
 
-RUN mkdir -p /app-cached/build
+RUN mkdir -p /app-cached
 RUN if [ -d "/app/build" ]; then mv /app/build /app-cached; fi
 RUN if [ -d "/app/vcpkg_installed" ]; then mv /app/vcpkg_installed /app-cached/build; fi
 
-RUN echo "cd \${CODECRAFTERS_REPOSITORY_DIR} && cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake && cmake --build ./build && sed -i '/^cmake/ s/^/# /' ./your_shell.sh" > /codecrafters-precompile.sh
-RUN chmod +x /codecrafters-precompile.sh

--- a/dockerfiles/go-1.22.Dockerfile
+++ b/dockerfiles/go-1.22.Dockerfile
@@ -11,6 +11,7 @@ COPY --exclude=.git --exclude=README.md . /app
 
 # Starting from Go 1.20, the go standard library is no loger compiled.
 # Setting GODEBUG to "installgoroot=all" restores the old behavior
+# hadolint ignore=DL3062
 RUN GODEBUG="installgoroot=all" go install std
 
 RUN go mod download

--- a/dockerfiles/go-1.24.Dockerfile
+++ b/dockerfiles/go-1.24.Dockerfile
@@ -11,6 +11,7 @@ COPY --exclude=.git --exclude=README.md . /app
 
 # Starting from Go 1.20, the go standard library is no loger compiled.
 # Setting GODEBUG to "installgoroot=all" restores the old behavior
+# hadolint ignore=DL3062
 RUN GODEBUG="installgoroot=all" go install std
 
 RUN go mod download

--- a/solutions/c/01-oo8/code/.codecrafters/run.sh
+++ b/solutions/c/01-oo8/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec $(dirname $0)/build/shell "$@"
+exec $(dirname "$0")/build/shell "$@"

--- a/solutions/c/01-oo8/code/your_program.sh
+++ b/solutions/c/01-oo8/code/your_program.sh
@@ -22,4 +22,4 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec $(dirname $0)/build/shell "$@"
+exec $(dirname "$0")/build/shell "$@"

--- a/solutions/c/02-cz2/code/.codecrafters/run.sh
+++ b/solutions/c/02-cz2/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec $(dirname $0)/build/shell "$@"
+exec $(dirname "$0")/build/shell "$@"

--- a/solutions/c/02-cz2/code/your_program.sh
+++ b/solutions/c/02-cz2/code/your_program.sh
@@ -22,4 +22,4 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec $(dirname $0)/build/shell "$@"
+exec $(dirname "$0")/build/shell "$@"

--- a/solutions/cpp/01-oo8/code/.codecrafters/compile.sh
+++ b/solutions/cpp/01-oo8/code/.codecrafters/compile.sh
@@ -1,13 +1,12 @@
 #!/bin/sh
 #
 # This script is used to compile your program on CodeCrafters
-# 
+#
 # This runs before .codecrafters/run.sh
 #
 # Learn more: https://codecrafters.io/program-interface
 
-# Exit early if any commands fail
-set -e
+set -e # Exit on failure
 
 cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake
 cmake --build ./build

--- a/solutions/cpp/01-oo8/code/.codecrafters/run.sh
+++ b/solutions/cpp/01-oo8/code/.codecrafters/run.sh
@@ -1,12 +1,11 @@
 #!/bin/sh
 #
 # This script is used to run your program on CodeCrafters
-# 
+#
 # This runs after .codecrafters/compile.sh
 #
 # Learn more: https://codecrafters.io/program-interface
 
-# Exit early if any commands fail
-set -e
+set -e # Exit on failure
 
-exec ./build/shell "$@"
+exec $(dirname "$0")/build/shell "$@"

--- a/solutions/cpp/01-oo8/code/your_program.sh
+++ b/solutions/cpp/01-oo8/code/your_program.sh
@@ -22,4 +22,4 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec ./build/shell "$@"
+exec $(dirname "$0")/build/shell "$@"

--- a/solutions/cpp/02-cz2/code/.codecrafters/compile.sh
+++ b/solutions/cpp/02-cz2/code/.codecrafters/compile.sh
@@ -1,13 +1,12 @@
 #!/bin/sh
 #
 # This script is used to compile your program on CodeCrafters
-# 
+#
 # This runs before .codecrafters/run.sh
 #
 # Learn more: https://codecrafters.io/program-interface
 
-# Exit early if any commands fail
-set -e
+set -e # Exit on failure
 
 cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake
 cmake --build ./build

--- a/solutions/cpp/02-cz2/code/.codecrafters/run.sh
+++ b/solutions/cpp/02-cz2/code/.codecrafters/run.sh
@@ -1,12 +1,11 @@
 #!/bin/sh
 #
 # This script is used to run your program on CodeCrafters
-# 
+#
 # This runs after .codecrafters/compile.sh
 #
 # Learn more: https://codecrafters.io/program-interface
 
-# Exit early if any commands fail
-set -e
+set -e # Exit on failure
 
-exec ./build/shell "$@"
+exec $(dirname "$0")/build/shell "$@"

--- a/solutions/cpp/02-cz2/code/your_program.sh
+++ b/solutions/cpp/02-cz2/code/your_program.sh
@@ -22,4 +22,4 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec ./build/shell "$@"
+exec $(dirname "$0")/build/shell "$@"

--- a/starter_templates/c/code/.codecrafters/run.sh
+++ b/starter_templates/c/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec $(dirname $0)/build/shell "$@"
+exec $(dirname "$0")/build/shell "$@"

--- a/starter_templates/cpp/code/.codecrafters/compile.sh
+++ b/starter_templates/cpp/code/.codecrafters/compile.sh
@@ -1,13 +1,12 @@
 #!/bin/sh
 #
 # This script is used to compile your program on CodeCrafters
-# 
+#
 # This runs before .codecrafters/run.sh
 #
 # Learn more: https://codecrafters.io/program-interface
 
-# Exit early if any commands fail
-set -e
+set -e # Exit on failure
 
 cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake
 cmake --build ./build

--- a/starter_templates/cpp/code/.codecrafters/run.sh
+++ b/starter_templates/cpp/code/.codecrafters/run.sh
@@ -1,12 +1,11 @@
 #!/bin/sh
 #
 # This script is used to run your program on CodeCrafters
-# 
+#
 # This runs after .codecrafters/compile.sh
 #
 # Learn more: https://codecrafters.io/program-interface
 
-# Exit early if any commands fail
-set -e
+set -e # Exit on failure
 
-exec ./build/shell "$@"
+exec $(dirname "$0")/build/shell "$@"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrade C/C++ images to gcc 14.3, update CMake and dependency paths, remove Go tooling from C++ image, and make run scripts path-safe via dirname quoting.
> 
> - **Docker**:
>   - **C**: Bump base image to `gcc:14.3.0-bookworm`; include `CMakeLists.txt` in `CODECRAFTERS_DEPENDENCY_FILE_PATHS`.
>   - **C++**: Bump base image to `gcc:14.3.0-bookworm`; upgrade CMake to `3.30.5`; include `CMakeLists.txt` in `CODECRAFTERS_DEPENDENCY_FILE_PATHS`; remove Go install and precompile script; simplify cache dirs (`/app-cached`).
>   - **Go (1.22/1.24)**: Add `hadolint` ignore for `GODEBUG` std install.
> - **Starter & Solution Scripts (C/C++)**:
>   - Make run commands path-safe by using `exec $(dirname "$0")/build/shell "$@"` (replacing `./build/shell` and unquoted `dirname $0`).
>   - Minor shell script cleanups (commented `set -e`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cdcf232388735c1ba437af40ff639778612b992. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->