### PR TITLE
Add Node.js note about fs.accessSync throwing errors

### DIFF
--- a/stage_descriptions/base-07-mg5.md
+++ b/stage_descriptions/base-07-mg5.md
@@ -58,3 +58,5 @@ The tester will verify that the `type` command correctly identifies executable f
 - Most languages provide functions to check execute permissions for a file (like `os.access(path, os.X_OK)` in Python, or `Files.isExecutable()` in Java).
 - PATH can include directories that don’t exist on disk, so your code should handle such cases gracefully.
 - When parsing the PATH environment variable, remember that the delimiter (usually `:` or `;`) can vary by operating system. Use OS-agnostic path handling provided by your language (like `os.pathsep` in Python, `File.pathSeparator` in Java, or `path.delimiter` in Node.js) to correctly split the directories.
+- In Node.js, `fs.accessSync(path, fs.constants.X_OK)` throws an error if the file doesn't exist or isn't executable (it doesn't return a boolean), so it should be used with `try/catch`.
+


### PR DESCRIPTION
Added a Node.js-specific note clarifying that fs.accessSync(..., fs.constants.X_OK) throws on failure and should be used with try/catch.