### PR TITLE
CC-2182: Upgrade Kotlin to v2.3

### DIFF
--- a/compiled_starters/kotlin/.codecrafters/compile.sh
+++ b/compiled_starters/kotlin/.codecrafters/compile.sh
@@ -16,7 +16,7 @@ KOTLIN_JVM_OPTS="-J--enable-native-access=ALL-UNNAMED -J--sun-misc-unsafe-memory
 if [ -d "$LIBS_DIR" ] && [ "$(ls -A "$LIBS_DIR" 2>/dev/null)" ] && command -v kotlinc >/dev/null 2>&1; then
   # Fast path: compile with kotlinc using pre-cached libraries
   mkdir -p "$KOTLIN_MAIN"
-  kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" app/src/main/kotlin/*.kt
+  find app/src/main/kotlin -type f -name '*.kt' -exec kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" {} +
 else
   # Full build: use Gradle to build and install distribution
   gradle installDist

--- a/compiled_starters/kotlin/codecrafters.yml
+++ b/compiled_starters/kotlin/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Kotlin version used to run your code
 # on Codecrafters.
 #
-# Available versions: kotlin-2.2
-buildpack: kotlin-2.2
+# Available versions: kotlin-2.3
+buildpack: kotlin-2.3

--- a/compiled_starters/kotlin/gradle/libs.versions.toml
+++ b/compiled_starters/kotlin/gradle/libs.versions.toml
@@ -2,4 +2,4 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [plugins]
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.2.0" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.3.20" }

--- a/compiled_starters/kotlin/your_program.sh
+++ b/compiled_starters/kotlin/your_program.sh
@@ -21,7 +21,7 @@ set -e # Exit early if any commands fail
   if [ -d "$LIBS_DIR" ] && [ "$(ls -A "$LIBS_DIR" 2>/dev/null)" ] && command -v kotlinc >/dev/null 2>&1; then
     # Fast path: compile with kotlinc using pre-cached libraries
     mkdir -p "$KOTLIN_MAIN"
-    kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" app/src/main/kotlin/*.kt
+    find app/src/main/kotlin -type f -name '*.kt' -exec kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" {} +
   else
     # Full build: use Gradle to build and install distribution
     gradle installDist

--- a/dockerfiles/kotlin-2.3.Dockerfile
+++ b/dockerfiles/kotlin-2.3.Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM gradle:jdk24-alpine
+
+# hadolint ignore=DL3018
+RUN apk add --no-cache bash curl unzip && \
+    curl -sL "https://github.com/JetBrains/kotlin/releases/download/v2.3.20/kotlin-compiler-2.3.20.zip" -o /tmp/kotlin.zip && \
+    unzip -q /tmp/kotlin.zip -d /opt/ && \
+    rm /tmp/kotlin.zip
+ENV PATH="/opt/kotlinc/bin:${PATH}"
+
+# Ensures the container is re-built if build files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="settings.gradle.kts,app/build.gradle.kts,gradle/libs.versions.toml"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# Install language-specific dependencies
+RUN .codecrafters/compile.sh
+
+RUN mkdir -p /app-cached
+RUN if [ -d "/app/.gradle" ]; then mv /app/.gradle /app-cached; fi

--- a/solutions/kotlin/01-oo8/code/.codecrafters/compile.sh
+++ b/solutions/kotlin/01-oo8/code/.codecrafters/compile.sh
@@ -16,7 +16,7 @@ KOTLIN_JVM_OPTS="-J--enable-native-access=ALL-UNNAMED -J--sun-misc-unsafe-memory
 if [ -d "$LIBS_DIR" ] && [ "$(ls -A "$LIBS_DIR" 2>/dev/null)" ] && command -v kotlinc >/dev/null 2>&1; then
   # Fast path: compile with kotlinc using pre-cached libraries
   mkdir -p "$KOTLIN_MAIN"
-  kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" app/src/main/kotlin/*.kt
+  find app/src/main/kotlin -type f -name '*.kt' -exec kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" {} +
 else
   # Full build: use Gradle to build and install distribution
   gradle installDist

--- a/solutions/kotlin/01-oo8/code/codecrafters.yml
+++ b/solutions/kotlin/01-oo8/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Kotlin version used to run your code
 # on Codecrafters.
 #
-# Available versions: kotlin-2.2
-buildpack: kotlin-2.2
+# Available versions: kotlin-2.3
+buildpack: kotlin-2.3

--- a/solutions/kotlin/01-oo8/code/gradle/libs.versions.toml
+++ b/solutions/kotlin/01-oo8/code/gradle/libs.versions.toml
@@ -2,4 +2,4 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [plugins]
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.2.0" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.3.20" }

--- a/solutions/kotlin/01-oo8/code/your_program.sh
+++ b/solutions/kotlin/01-oo8/code/your_program.sh
@@ -21,7 +21,7 @@ set -e # Exit early if any commands fail
   if [ -d "$LIBS_DIR" ] && [ "$(ls -A "$LIBS_DIR" 2>/dev/null)" ] && command -v kotlinc >/dev/null 2>&1; then
     # Fast path: compile with kotlinc using pre-cached libraries
     mkdir -p "$KOTLIN_MAIN"
-    kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" app/src/main/kotlin/*.kt
+    find app/src/main/kotlin -type f -name '*.kt' -exec kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" {} +
   else
     # Full build: use Gradle to build and install distribution
     gradle installDist

--- a/solutions/kotlin/02-cz2/code/.codecrafters/compile.sh
+++ b/solutions/kotlin/02-cz2/code/.codecrafters/compile.sh
@@ -16,7 +16,7 @@ KOTLIN_JVM_OPTS="-J--enable-native-access=ALL-UNNAMED -J--sun-misc-unsafe-memory
 if [ -d "$LIBS_DIR" ] && [ "$(ls -A "$LIBS_DIR" 2>/dev/null)" ] && command -v kotlinc >/dev/null 2>&1; then
   # Fast path: compile with kotlinc using pre-cached libraries
   mkdir -p "$KOTLIN_MAIN"
-  kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" app/src/main/kotlin/*.kt
+  find app/src/main/kotlin -type f -name '*.kt' -exec kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" {} +
 else
   # Full build: use Gradle to build and install distribution
   gradle installDist

--- a/solutions/kotlin/02-cz2/code/codecrafters.yml
+++ b/solutions/kotlin/02-cz2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Kotlin version used to run your code
 # on Codecrafters.
 #
-# Available versions: kotlin-2.2
-buildpack: kotlin-2.2
+# Available versions: kotlin-2.3
+buildpack: kotlin-2.3

--- a/solutions/kotlin/02-cz2/code/gradle/libs.versions.toml
+++ b/solutions/kotlin/02-cz2/code/gradle/libs.versions.toml
@@ -2,4 +2,4 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [plugins]
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.2.0" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.3.20" }

--- a/solutions/kotlin/02-cz2/code/your_program.sh
+++ b/solutions/kotlin/02-cz2/code/your_program.sh
@@ -21,7 +21,7 @@ set -e # Exit early if any commands fail
   if [ -d "$LIBS_DIR" ] && [ "$(ls -A "$LIBS_DIR" 2>/dev/null)" ] && command -v kotlinc >/dev/null 2>&1; then
     # Fast path: compile with kotlinc using pre-cached libraries
     mkdir -p "$KOTLIN_MAIN"
-    kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" app/src/main/kotlin/*.kt
+    find app/src/main/kotlin -type f -name '*.kt' -exec kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" {} +
   else
     # Full build: use Gradle to build and install distribution
     gradle installDist

--- a/solutions/kotlin/03-ff0/code/.codecrafters/compile.sh
+++ b/solutions/kotlin/03-ff0/code/.codecrafters/compile.sh
@@ -16,7 +16,7 @@ KOTLIN_JVM_OPTS="-J--enable-native-access=ALL-UNNAMED -J--sun-misc-unsafe-memory
 if [ -d "$LIBS_DIR" ] && [ "$(ls -A "$LIBS_DIR" 2>/dev/null)" ] && command -v kotlinc >/dev/null 2>&1; then
   # Fast path: compile with kotlinc using pre-cached libraries
   mkdir -p "$KOTLIN_MAIN"
-  kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" app/src/main/kotlin/*.kt
+  find app/src/main/kotlin -type f -name '*.kt' -exec kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" {} +
 else
   # Full build: use Gradle to build and install distribution
   gradle installDist

--- a/solutions/kotlin/03-ff0/code/codecrafters.yml
+++ b/solutions/kotlin/03-ff0/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Kotlin version used to run your code
 # on Codecrafters.
 #
-# Available versions: kotlin-2.2
-buildpack: kotlin-2.2
+# Available versions: kotlin-2.3
+buildpack: kotlin-2.3

--- a/solutions/kotlin/03-ff0/code/gradle/libs.versions.toml
+++ b/solutions/kotlin/03-ff0/code/gradle/libs.versions.toml
@@ -2,4 +2,4 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [plugins]
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.2.0" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.3.20" }

--- a/solutions/kotlin/03-ff0/code/your_program.sh
+++ b/solutions/kotlin/03-ff0/code/your_program.sh
@@ -21,7 +21,7 @@ set -e # Exit early if any commands fail
   if [ -d "$LIBS_DIR" ] && [ "$(ls -A "$LIBS_DIR" 2>/dev/null)" ] && command -v kotlinc >/dev/null 2>&1; then
     # Fast path: compile with kotlinc using pre-cached libraries
     mkdir -p "$KOTLIN_MAIN"
-    kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" app/src/main/kotlin/*.kt
+    find app/src/main/kotlin -type f -name '*.kt' -exec kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" {} +
   else
     # Full build: use Gradle to build and install distribution
     gradle installDist

--- a/solutions/kotlin/04-pn5/code/.codecrafters/compile.sh
+++ b/solutions/kotlin/04-pn5/code/.codecrafters/compile.sh
@@ -16,7 +16,7 @@ KOTLIN_JVM_OPTS="-J--enable-native-access=ALL-UNNAMED -J--sun-misc-unsafe-memory
 if [ -d "$LIBS_DIR" ] && [ "$(ls -A "$LIBS_DIR" 2>/dev/null)" ] && command -v kotlinc >/dev/null 2>&1; then
   # Fast path: compile with kotlinc using pre-cached libraries
   mkdir -p "$KOTLIN_MAIN"
-  kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" app/src/main/kotlin/*.kt
+  find app/src/main/kotlin -type f -name '*.kt' -exec kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" {} +
 else
   # Full build: use Gradle to build and install distribution
   gradle installDist

--- a/solutions/kotlin/04-pn5/code/codecrafters.yml
+++ b/solutions/kotlin/04-pn5/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Kotlin version used to run your code
 # on Codecrafters.
 #
-# Available versions: kotlin-2.2
-buildpack: kotlin-2.2
+# Available versions: kotlin-2.3
+buildpack: kotlin-2.3

--- a/solutions/kotlin/04-pn5/code/gradle/libs.versions.toml
+++ b/solutions/kotlin/04-pn5/code/gradle/libs.versions.toml
@@ -2,4 +2,4 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [plugins]
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.2.0" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.3.20" }

--- a/solutions/kotlin/04-pn5/code/your_program.sh
+++ b/solutions/kotlin/04-pn5/code/your_program.sh
@@ -21,7 +21,7 @@ set -e # Exit early if any commands fail
   if [ -d "$LIBS_DIR" ] && [ "$(ls -A "$LIBS_DIR" 2>/dev/null)" ] && command -v kotlinc >/dev/null 2>&1; then
     # Fast path: compile with kotlinc using pre-cached libraries
     mkdir -p "$KOTLIN_MAIN"
-    kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" app/src/main/kotlin/*.kt
+    find app/src/main/kotlin -type f -name '*.kt' -exec kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" {} +
   else
     # Full build: use Gradle to build and install distribution
     gradle installDist

--- a/solutions/kotlin/05-iz3/code/.codecrafters/compile.sh
+++ b/solutions/kotlin/05-iz3/code/.codecrafters/compile.sh
@@ -16,7 +16,7 @@ KOTLIN_JVM_OPTS="-J--enable-native-access=ALL-UNNAMED -J--sun-misc-unsafe-memory
 if [ -d "$LIBS_DIR" ] && [ "$(ls -A "$LIBS_DIR" 2>/dev/null)" ] && command -v kotlinc >/dev/null 2>&1; then
   # Fast path: compile with kotlinc using pre-cached libraries
   mkdir -p "$KOTLIN_MAIN"
-  kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" app/src/main/kotlin/*.kt
+  find app/src/main/kotlin -type f -name '*.kt' -exec kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" {} +
 else
   # Full build: use Gradle to build and install distribution
   gradle installDist

--- a/solutions/kotlin/05-iz3/code/codecrafters.yml
+++ b/solutions/kotlin/05-iz3/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Kotlin version used to run your code
 # on Codecrafters.
 #
-# Available versions: kotlin-2.2
-buildpack: kotlin-2.2
+# Available versions: kotlin-2.3
+buildpack: kotlin-2.3

--- a/solutions/kotlin/05-iz3/code/gradle/libs.versions.toml
+++ b/solutions/kotlin/05-iz3/code/gradle/libs.versions.toml
@@ -2,4 +2,4 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [plugins]
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.2.0" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.3.20" }

--- a/solutions/kotlin/05-iz3/code/your_program.sh
+++ b/solutions/kotlin/05-iz3/code/your_program.sh
@@ -21,7 +21,7 @@ set -e # Exit early if any commands fail
   if [ -d "$LIBS_DIR" ] && [ "$(ls -A "$LIBS_DIR" 2>/dev/null)" ] && command -v kotlinc >/dev/null 2>&1; then
     # Fast path: compile with kotlinc using pre-cached libraries
     mkdir -p "$KOTLIN_MAIN"
-    kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" app/src/main/kotlin/*.kt
+    find app/src/main/kotlin -type f -name '*.kt' -exec kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" {} +
   else
     # Full build: use Gradle to build and install distribution
     gradle installDist

--- a/starter_templates/kotlin/code/.codecrafters/compile.sh
+++ b/starter_templates/kotlin/code/.codecrafters/compile.sh
@@ -16,7 +16,7 @@ KOTLIN_JVM_OPTS="-J--enable-native-access=ALL-UNNAMED -J--sun-misc-unsafe-memory
 if [ -d "$LIBS_DIR" ] && [ "$(ls -A "$LIBS_DIR" 2>/dev/null)" ] && command -v kotlinc >/dev/null 2>&1; then
   # Fast path: compile with kotlinc using pre-cached libraries
   mkdir -p "$KOTLIN_MAIN"
-  kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" app/src/main/kotlin/*.kt
+  find app/src/main/kotlin -type f -name '*.kt' -exec kotlinc $KOTLIN_JVM_OPTS -cp "$(echo "$LIBS_DIR"/*.jar | tr ' ' ':')" -d "$KOTLIN_MAIN" {} +
 else
   # Full build: use Gradle to build and install distribution
   gradle installDist

--- a/starter_templates/kotlin/code/gradle/libs.versions.toml
+++ b/starter_templates/kotlin/code/gradle/libs.versions.toml
@@ -2,4 +2,4 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [plugins]
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.2.0" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.3.20" }


### PR DESCRIPTION
CC-2182: Upgrade Kotlin to v2.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades the Kotlin toolchain and buildpack version, which can introduce compilation/runtime regressions across all Kotlin starters/solutions. Also changes the fast-path compilation command, potentially affecting which source files are compiled.
> 
> **Overview**
> Upgrades the Kotlin buildpack/toolchain from `kotlin-2.2` to `kotlin-2.3` (Kotlin Gradle plugin `2.3.20`) across the Kotlin compiled starter, templates, and bundled solutions.
> 
> Updates the cached fast-path compilation in `.codecrafters/compile.sh` and `your_program.sh` to compile **all** Kotlin sources under `app/src/main/kotlin` via `find` instead of relying on a `*.kt` glob.
> 
> Adds a new `kotlin-2.3` Docker image definition downloading the `2.3.20` compiler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbf21cc307718f3e7b20e94e4b74866ac15019d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->