### PR TITLE
CC-2188: Upgrade Scala to v3.8

### DIFF
--- a/compiled_starters/scala/.codecrafters/compile.sh
+++ b/compiled_starters/scala/.codecrafters/compile.sh
@@ -9,5 +9,5 @@
 set -e # Exit on failure
 
 scala-cli package src/main/scala/ \
-  -q --power --assembly --force --server=false --scala-version=3.8.2 \
+  -q --power --assembly --force --server=false --scala-version=3.8.3 \
   -o /tmp/codecrafters-build-shell-scala

--- a/compiled_starters/scala/your_program.sh
+++ b/compiled_starters/scala/your_program.sh
@@ -15,7 +15,7 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   scala-cli package src/main/scala/ \
-    -q --power --assembly --force --server=false --scala-version=3.8.2 \
+    -q --power --assembly --force --server=false --scala-version=3.8.3 \
     -o /tmp/codecrafters-build-shell-scala
 )
 

--- a/dockerfiles/scala-3.8.Dockerfile
+++ b/dockerfiles/scala-3.8.Dockerfile
@@ -3,7 +3,8 @@ FROM eclipse-temurin:25-jdk-alpine-3.23
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
-RUN apk add --no-cache --upgrade bash=5.3.3-r1 && \
+# hadolint ignore=DL3018
+RUN apk add --no-cache --upgrade bash curl && \
     curl -fsSL https://github.com/VirtusLab/scala-cli/releases/latest/download/scala-cli-x86_64-pc-linux-static.gz | gzip -d > /usr/local/bin/scala-cli && \
     chmod +x /usr/local/bin/scala-cli
 

--- a/solutions/scala/01-oo8/code/.codecrafters/compile.sh
+++ b/solutions/scala/01-oo8/code/.codecrafters/compile.sh
@@ -9,5 +9,5 @@
 set -e # Exit on failure
 
 scala-cli package src/main/scala/ \
-  -q --power --assembly --force --server=false --scala-version=3.8.2 \
+  -q --power --assembly --force --server=false --scala-version=3.8.3 \
   -o /tmp/codecrafters-build-shell-scala

--- a/solutions/scala/01-oo8/code/your_program.sh
+++ b/solutions/scala/01-oo8/code/your_program.sh
@@ -15,7 +15,7 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   scala-cli package src/main/scala/ \
-    -q --power --assembly --force --server=false --scala-version=3.8.2 \
+    -q --power --assembly --force --server=false --scala-version=3.8.3 \
     -o /tmp/codecrafters-build-shell-scala
 )
 

--- a/solutions/scala/02-cz2/code/.codecrafters/compile.sh
+++ b/solutions/scala/02-cz2/code/.codecrafters/compile.sh
@@ -9,5 +9,5 @@
 set -e # Exit on failure
 
 scala-cli package src/main/scala/ \
-  -q --power --assembly --force --server=false --scala-version=3.8.2 \
+  -q --power --assembly --force --server=false --scala-version=3.8.3 \
   -o /tmp/codecrafters-build-shell-scala

--- a/solutions/scala/02-cz2/code/your_program.sh
+++ b/solutions/scala/02-cz2/code/your_program.sh
@@ -15,7 +15,7 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   scala-cli package src/main/scala/ \
-    -q --power --assembly --force --server=false --scala-version=3.8.2 \
+    -q --power --assembly --force --server=false --scala-version=3.8.3 \
     -o /tmp/codecrafters-build-shell-scala
 )
 

--- a/solutions/scala/03-ff0/code/.codecrafters/compile.sh
+++ b/solutions/scala/03-ff0/code/.codecrafters/compile.sh
@@ -9,5 +9,5 @@
 set -e # Exit on failure
 
 scala-cli package src/main/scala/ \
-  -q --power --assembly --force --server=false --scala-version=3.8.2 \
+  -q --power --assembly --force --server=false --scala-version=3.8.3 \
   -o /tmp/codecrafters-build-shell-scala

--- a/solutions/scala/03-ff0/code/your_program.sh
+++ b/solutions/scala/03-ff0/code/your_program.sh
@@ -15,7 +15,7 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   scala-cli package src/main/scala/ \
-    -q --power --assembly --force --server=false --scala-version=3.8.2 \
+    -q --power --assembly --force --server=false --scala-version=3.8.3 \
     -o /tmp/codecrafters-build-shell-scala
 )
 

--- a/solutions/scala/04-pn5/code/.codecrafters/compile.sh
+++ b/solutions/scala/04-pn5/code/.codecrafters/compile.sh
@@ -9,5 +9,5 @@
 set -e # Exit on failure
 
 scala-cli package src/main/scala/ \
-  -q --power --assembly --force --server=false --scala-version=3.8.2 \
+  -q --power --assembly --force --server=false --scala-version=3.8.3 \
   -o /tmp/codecrafters-build-shell-scala

--- a/solutions/scala/04-pn5/code/your_program.sh
+++ b/solutions/scala/04-pn5/code/your_program.sh
@@ -15,7 +15,7 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   scala-cli package src/main/scala/ \
-    -q --power --assembly --force --server=false --scala-version=3.8.2 \
+    -q --power --assembly --force --server=false --scala-version=3.8.3 \
     -o /tmp/codecrafters-build-shell-scala
 )
 

--- a/solutions/scala/05-iz3/code/.codecrafters/compile.sh
+++ b/solutions/scala/05-iz3/code/.codecrafters/compile.sh
@@ -9,5 +9,5 @@
 set -e # Exit on failure
 
 scala-cli package src/main/scala/ \
-  -q --power --assembly --force --server=false --scala-version=3.8.2 \
+  -q --power --assembly --force --server=false --scala-version=3.8.3 \
   -o /tmp/codecrafters-build-shell-scala

--- a/solutions/scala/05-iz3/code/your_program.sh
+++ b/solutions/scala/05-iz3/code/your_program.sh
@@ -15,7 +15,7 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   scala-cli package src/main/scala/ \
-    -q --power --assembly --force --server=false --scala-version=3.8.2 \
+    -q --power --assembly --force --server=false --scala-version=3.8.3 \
     -o /tmp/codecrafters-build-shell-scala
 )
 

--- a/starter_templates/scala/code/.codecrafters/compile.sh
+++ b/starter_templates/scala/code/.codecrafters/compile.sh
@@ -9,5 +9,5 @@
 set -e # Exit on failure
 
 scala-cli package src/main/scala/ \
-  -q --power --assembly --force --server=false --scala-version=3.8.2 \
+  -q --power --assembly --force --server=false --scala-version=3.8.3 \
   -o /tmp/codecrafters-build-shell-scala


### PR DESCRIPTION
CC-2188: Upgrade Scala to v3.8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the Scala compiler version used across starters/solutions and adjusts the Docker build dependencies, which can affect build reproducibility and compilation behavior.
> 
> **Overview**
> Upgrades all Scala starter/solution build scripts (`.codecrafters/compile.sh` and `your_program.sh`) to compile with **Scala 3.8.3** instead of 3.8.2.
> 
> Updates the Scala 3.8 Docker image to install `bash` and `curl` without pinning a specific `bash` package version (and adds a hadolint ignore), while still downloading `scala-cli` at build time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70e5e13c4bcb4b2ea1c5bc722e4e001a62548c81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->