### PR TITLE
Reduce Redirection's dependence on Quoting

### DIFF
--- a/stage_descriptions/redirection-01-jv1.md
+++ b/stage_descriptions/redirection-01-jv1.md
@@ -58,7 +58,7 @@ $ cat /tmp/foo/baz.md
 apple
 blueberry
 
-$ echo 'Hello James' 1> /tmp/foo/foo.md
+$ echo Hello James 1> /tmp/foo/foo.md
 $ cat /tmp/foo/foo.md
 Hello James
 

--- a/stage_descriptions/redirection-02-vz4.md
+++ b/stage_descriptions/redirection-02-vz4.md
@@ -47,7 +47,7 @@ $ ls nonexistent 2> /tmp/quz/baz.md
 $ cat /tmp/quz/baz.md
 ls: nonexistent: No such file or directory
 
-$ echo 'Maria file cannot be found' 2> /tmp/quz/foo.md
+$ echo Maria file cannot be found 2> /tmp/quz/foo.md
 Maria file cannot be found
 $ 
 

--- a/stage_descriptions/redirection-03-el9.md
+++ b/stage_descriptions/redirection-03-el9.md
@@ -32,13 +32,13 @@ apple
 banana
 blueberry
 
-$ echo 'Hello Emily' 1>> /tmp/bar/baz.md
-$ echo 'Hello Maria' 1>> /tmp/bar/baz.md
+$ echo Hello Emily 1>> /tmp/bar/baz.md
+$ echo Hello Maria 1>> /tmp/bar/baz.md
 $ cat /tmp/bar/baz.md
 Hello Emily
 Hello Maria
 
-$ echo "List of files: " > /tmp/bar/qux.md
+$ echo List of files: > /tmp/bar/qux.md
 $ ls /tmp/baz >> /tmp/bar/qux.md
 $ cat /tmp/bar/qux.md
 List of files:

--- a/stage_descriptions/redirection-04-un3.md
+++ b/stage_descriptions/redirection-04-un3.md
@@ -34,7 +34,7 @@ $ ls nonexistent 2>> /tmp/foo/qux.md
 $ cat /tmp/foo/qux.md
 ls: nonexistent: No such file or directory
 
-$ echo "James says Error" 2>> /tmp/foo/quz.md
+$ echo James says Error 2>> /tmp/foo/quz.md
 James says Error
 
 $ cat nonexistent 2>> /tmp/foo/quz.md


### PR DESCRIPTION
In tandem: https://github.com/codecrafters-io/shell-tester/pull/284

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust example commands; no production code or runtime behavior is modified, but learners following prior quoted examples may notice the updated syntax.
> 
> **Overview**
> Updates the redirection stage descriptions to **remove reliance on shell quoting** in `echo` examples, using unquoted arguments across `>`, `2>`, `>>`, and `2>>` scenarios.
> 
> Also tweaks one example to emit `List of files:` without surrounding quotes, keeping expected redirected/printed output the same while making the stages less dependent on quote parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecc7aa6d245ed6454b8f49f4585b1e1997e7c038. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->