### PR TITLE
Programmable Completion Updates

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -444,28 +444,28 @@ stages:
     name: "Display registered completions"
     difficulty: medium
     marketing_md: |-
-      In this stage, you'll add support for displaying the registered completion using the `complete` builtin.
+      In this stage, you'll add support for the `-p` flag for the `complete` builtin.
 
   - slug: "wl6"
     primary_extension_slug: "programmable-completion"
     name: "Command based completion"
     difficulty: medium
     marketing_md: |-
-      In this stage, you'll add support for `-C` option in the `complete` builtin.
+      In this stage, you'll add support for displaying the registered completion using the `complete` builtin.
 
   - slug: "pm5"
     primary_extension_slug: "programmable-completion"
     name: "Handling no completions"
     difficulty: easy
     marketing_md: |-
-      In this stage, you'll handle the case where the completer produces no completion candidates.
+      In this stage, you'll add support for `-C` option in the `complete` builtin.
 
   - slug: "qf1"
     primary_extension_slug: "programmable-completion"
     name: "Handling completer's stderr"
     difficulty: medium
     marketing_md: |-
-      In this stage, you'll add support for handling the completer script's stderr.
+      In this stage, you'll handle the case where the completer produces no completion candidates.
 
   - slug: "zi0"
     primary_extension_slug: "programmable-completion"

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -451,14 +451,14 @@ stages:
     name: "Displaying registered specifications"
     difficulty: medium
     marketing_md: |-
-      In this stage, you'll add support for displaying the registered completion using the `complete` builtin.
+      In this stage, you'll add support for `-C` option in the `complete` builtin and displaying the registered completions.
 
   - slug: "pm5"
     primary_extension_slug: "programmable-completion"
-    name: "Command based completion"
+    name: "Single completion"
     difficulty: medium 
     marketing_md: |-
-      In this stage, you'll add support for `-C` option in the `complete` builtin.
+      In this stage, you'll add support for completing to a single candidate.
 
   - slug: "qf1"
     primary_extension_slug: "programmable-completion"

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -441,29 +441,29 @@ stages:
 
   - slug: "oi7"
     primary_extension_slug: "programmable-completion"
-    name: "Display registered completions"
-    difficulty: medium
+    name: "Printing missing specifications"
+    difficulty: easy
     marketing_md: |-
       In this stage, you'll add support for the `-p` flag for the `complete` builtin.
 
   - slug: "wl6"
     primary_extension_slug: "programmable-completion"
-    name: "Command based completion"
+    name: "Displaying registered specifications"
     difficulty: medium
     marketing_md: |-
       In this stage, you'll add support for displaying the registered completion using the `complete` builtin.
 
   - slug: "pm5"
     primary_extension_slug: "programmable-completion"
-    name: "Handling no completions"
-    difficulty: easy
+    name: "Command based completion"
+    difficulty: medium 
     marketing_md: |-
       In this stage, you'll add support for `-C` option in the `complete` builtin.
 
   - slug: "qf1"
     primary_extension_slug: "programmable-completion"
-    name: "Handling completer's stderr"
-    difficulty: medium
+    name: "Handling no completions"
+    difficulty: easy
     marketing_md: |-
       In this stage, you'll handle the case where the completer produces no completion candidates.
 

--- a/stage_descriptions/programmable-completion-01-ne7.md
+++ b/stage_descriptions/programmable-completion-01-ne7.md
@@ -31,14 +31,6 @@ $ type complete
 complete is a shell builtin
 ```
 
-The tester will also type the `complete` built-in to the shell.
-
-```bash
-# Expected: No output
-$ complete
-$ 
-```
-
 ### Notes
 
-- In this stage, you'll register `complete` as a builtin and write an empty implementation for it. You don't need to write the actual implementation of it yet. We'll get to that in the later stages.
+- In this stage, you'll register `complete` as a builtin. You don't need to write the actual implementation of it yet. We'll get to that in the later stages.

--- a/stage_descriptions/programmable-completion-02-oi7.md
+++ b/stage_descriptions/programmable-completion-02-oi7.md
@@ -1,4 +1,4 @@
-In this stage, you'll add support for displaying the registered completion using the `complete` builtin.
+In this stage, you'll add support for the `-p` flag for the `complete` builtin.
 
 ### The `-p` flag
 

--- a/stage_descriptions/programmable-completion-02-oi7.md
+++ b/stage_descriptions/programmable-completion-02-oi7.md
@@ -1,20 +1,17 @@
 In this stage, you'll add support for displaying the registered completion using the `complete` builtin.
 
-### The `complete` Builtin
+### The `-p` flag
 
-The [`complete`](https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html#index-complete) builtin lets the shell register and list programmable completions for commands.
+The `-p` flag prints the completion specification registered for a given command in a reusable format.
 
-The `complete` builtin without any flags displays the completions registered so far.
+If no specification has been registered, the shell prints an error message indicating there's no completion specification for that command.
 
 For example:
 
 ```bash
-# Register the script as the completer script for the 'git' command
-$ complete -C /path/to/completer/script git
-# Make use of the registered completion
-$ complete
-complete -C /path/to/completer/script git
-$
+# See the autocompletion specification for the 'git' command
+$ complete -p git
+complete: git: no completion specification
 ```
 
 ### Tests
@@ -25,17 +22,13 @@ The tester will execute your program like this:
 $ ./your_shell.sh
 ```
 
-It will then use the `complete` builtin to list the registered completions.
+It will then use the `-p` flag with the `complete` builtin.
 
 ```bash
-# Registration command may have spaces between arguments
-$ complete  -C  /path/to/completer/script  git
-# Output should not have spaces between arguments
-# The path should be surrounded with single quotes
-$ complete
-complete -C '/path/to/completer/script' git
+$ complete -p git
+complete: git: no completion specification
 ```
 
 ### Notes
 
-- You should parse the arguments and display them in the correct format while displaying the output of the `complete` builtin and not copy the command used to register the completion.
+- You can hardcode the output for this stage. We'll get to keeping track of completion specifications in the later stages.

--- a/stage_descriptions/programmable-completion-03-wl6.md
+++ b/stage_descriptions/programmable-completion-03-wl6.md
@@ -1,4 +1,4 @@
-In this stage, you'll add support for displaying the registered completion using the `complete` builtin.
+In this stage, you'll add support for `-C` option in the `complete` builtin and displaying the registered completions.
 
 ### Displaying registered completion
 

--- a/stage_descriptions/programmable-completion-03-wl6.md
+++ b/stage_descriptions/programmable-completion-03-wl6.md
@@ -1,40 +1,21 @@
-In this stage, you'll add support for `-C` option in the `complete` builtin.
+In this stage, you'll add support for displaying the registered completion using the `complete` builtin.
 
-### Command-based programmable completion
+### Displaying registered completion
 
-The `complete` builtin supports `-C`, which registers an external command that your shell should run when tab completion is requested for a specific command name.
+The [`complete`](https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html#index-complete) builtin lets the shell register and list programmable completions for commands.
 
-If the user runs `complete -C /path/to/git_completer_script.py git`, the shell registers that completion rule and prints nothing.
+The `complete` builtin with the `-p` flag displays the completion registered for the specified command.
 
-When the user later types `git ` and presses tab, the shell runs the registered completer script, reads its stdout, and uses that output as completion candidates. The completer script can be in any language.
-
-A high-level flow looks like this:
-1. The user types a partial command and presses tab.
-2. The shell intercepts the tab keypress.
-3. The shell looks up the completion rule for that command name and finds the `-C` rule.
-4. The shell starts the completer script using `fork()` and `exec()`.
-5. The completer script prints completion candidates to stdout.
-6. The shell reads the stdout of the completer script.
-7. Each line of the stdout is a completion candidate.
-
-The completer script will offer only one completion candidate for this stage.
-
-For example, the completer script that offers 'clone' completion can look like this:
-
-```python
-#!/usr/bin/env python3
-print("clone")
-```
+For example:
 
 ```bash
-$ complete -C /path/to/completer/script.py git
-$ git <TAB>
-# Since the completer script only offers 'clone' as the completion option
-# It autocompletes to 'clone' with a trailing space
-$ git clone 
+$ complete -C /path/to/git/completer git
+$ complete -C /path/to/docker/completer docker
+$ complete -p git
+complete -C '/path/to/git/completer' git
+$ complete -p docker
+complete -C '/path/to/docker/completer' docker
 ```
-
-In this stage, you only need to support a completer that prints a single candidate word each time.
 
 ### Tests
 
@@ -44,31 +25,20 @@ The tester will execute your program like this:
 $ ./your_shell.sh
 ```
 
-The tester will create a completer script that will always print the following:
-```
-clone
-```
-
-It will register a command-based completion rule.
+It will then use the `complete` builtin to list the registered completions.
 
 ```bash
-$ complete -C /path/to/completer/script.py git
-$ 
+# Registration command may have spaces between arguments
+# Output of -p flag should not have spaces between arguments
+# The path should be surrounded with single quotes
+$ complete  -C  /path/to/completer/script  git
+$ complete -p git
+complete -C '/path/to/completer/script' git
+$ complete   -C /path/to/docker/completer    docker
+$ complete -p docker
+complete -C '/path/to/docker/completer' docker
 ```
-
-The tester will then type `git ` and press tab.
-
-```bash
-$ git <TAB>
-# Autocompletes to clone because the completion
-# offers 'clone' as the only option
-$ git clone 
-```
-
-The tester will verify that tab completion uses the completer script output and inserts the single returned word with a trailing space.
 
 ### Notes
 
-- The completer script will print a single line to stdout. 
-
-- You do not need to support passing extra completion context into the completer yet. We'll add those details in later stages.
+- You should parse the arguments and display them in the correct format while displaying the output of the `complete -p` and not copy the command used to register the completion.

--- a/stage_descriptions/programmable-completion-04-pm5.md
+++ b/stage_descriptions/programmable-completion-04-pm5.md
@@ -1,18 +1,40 @@
-In this stage, you'll handle the case where the completer produces no completion candidates.
+In this stage, you'll add support for `-C` option in the `complete` builtin.
 
-### No completion candidates
+### Command-based programmable completion
 
-When the user presses tab and the shell runs the registered completer script, the shell reads standard output and treats line as a candidate. If the completer prints nothing to standard output, there are no candidates to apply.
+The `complete` builtin supports `-C`, which registers an external command that your shell should run when tab completion is requested for a specific command name.
 
-In that case the shell should not insert text or replace the current word. It should print the bell character (`\x07`) to standard output.
+If the user runs `complete -C /path/to/docker_completer_script.py docker`, the shell registers that completion rule and prints nothing.
 
-For example:
+When the user later types `docker ` and presses tab, the shell runs the registered completer script, reads its stdout, and uses that output as completion candidates. The completer script can be in any language.
+
+A high-level flow looks like this:
+1. The user types a partial command and presses tab.
+2. The shell intercepts the tab keypress.
+3. The shell looks up the completion rule for that command name and finds the `-C` rule.
+4. The shell starts the completer script using `fork()` and `exec()`.
+5. The completer script prints completion candidates to stdout.
+6. The shell reads the stdout of the completer script.
+7. Each line of the stdout is a completion candidate.
+
+The completer script will offer only one completion candidate for this stage.
+
+For example, the completer script that offers `run` completion can look like this:
+
+```python
+#!/usr/bin/env python3
+print("run")
+```
 
 ```bash
-$ complete -C /path/to/completer_script git
-$ git xyz<TAB>
-# Bell (\x07); line unchanged
+$ complete -C /path/to/completer/script.py docker
+$ docker <TAB>
+# Since the completer script only offers 'run' as the completion option
+# It autocompletes to 'run' with a trailing space
+$ docker run
 ```
+
+In this stage, you only need to support a completer that prints a single candidate word each time.
 
 ### Tests
 
@@ -22,23 +44,31 @@ The tester will execute your program like this:
 $ ./your_shell.sh
 ```
 
-It will register a command-based completion rule for a command such as `git`. The `complete` command should produce no output.
+The tester will create a completer script that will always print the following:
+```
+run
+```
+
+It will register a command-based completion rule.
 
 ```bash
-$ complete -C /path/to/completer_script git
-$
+$ complete -C /path/to/completer/script.py docker
+$ 
 ```
 
-The tester will supply a completer script that prints nothing to the stdout. For example, the script might look something like this:
-
-```python
-#!/usr/bin/python3
-exit(0)
-```
+The tester will then type `docker ` and press tab.
 
 ```bash
-# Expect: bell only; input line unchanged
-$ git xyz<TAB>
+$ docker <TAB>
+# Autocompletes to run because the completion
+# offers 'run' as the only option
+$ docker run
 ```
 
-The tester will verify that the input line is unchanged after the tab press and that the bell character is printed to standard output.
+The tester will verify that tab completion uses the completer script output and inserts the single returned word with a trailing space.
+
+### Notes
+
+- The completer script will print a single line to stdout. 
+
+- You do not need to support passing extra completion context into the completer yet. We'll add those details in later stages.

--- a/stage_descriptions/programmable-completion-04-pm5.md
+++ b/stage_descriptions/programmable-completion-04-pm5.md
@@ -1,4 +1,4 @@
-In this stage, you'll add support for `-C` option in the `complete` builtin.
+In this stage, you'll add support for completing to a single candidate.
 
 ### Command-based programmable completion
 

--- a/stage_descriptions/programmable-completion-05-qf1.md
+++ b/stage_descriptions/programmable-completion-05-qf1.md
@@ -1,40 +1,18 @@
-In this stage, you'll add support for handling the completer script's stderr
+In this stage, you'll handle the case where the completer produces no completion candidates.
 
-### Streaming completer's stderr
+### No completion candidates
 
-Anything the completer writes to standard error must appear on the user's terminal exactly as written (same bytes, same line breaks). The shell must copy standard error to the terminal as it becomes available while the completer is still running. It must not buffer standard error until the completer process exits.
+When the user presses tab and the shell runs the registered completer script, the shell reads standard output and treats line as a candidate. If the completer prints nothing to standard output, there are no candidates to apply.
 
-The tester may use a completer that writes known lines to standard error and then sleeps for a long time so the process stays alive. For example:
-
-```python
-#!/usr/bin/env python3
-import sys
-import time
-
-print("Line1", file=sys.stderr, flush=True)
-print("Line2", file=sys.stderr, flush=True)
-print("Line3", file=sys.stderr, flush=True)
-time.sleep(100)
-```
-
-Those three lines must be visible on the terminal during completion, before the long sleep finishes and before the process exits.
+In that case the shell should not insert text or replace the current word. It should print the bell character (`\x07`) to standard output.
 
 For example:
 
 ```bash
-$ complete -C /path/to/completer_script git
-$ git <TAB>
+$ complete -C /path/to/completer_script docker
+$ docker xyz<TAB>
+# Bell (\x07); line unchanged
 ```
-
-```bash
-$ git Line1
-Line2
-Line3
-```
-
-- The bell does not ring because the process have not exitted yet so the shell cannot determine if completion candidates exist or not.
-
-- The lines written to standard error show on the terminal as they are produced, without waiting for the completer to finish.
 
 ### Tests
 
@@ -44,33 +22,23 @@ The tester will execute your program like this:
 $ ./your_shell.sh
 ```
 
-It will create a completer script that prints contents to stderr, but does not exit. For example:
-
-```python
-#!/usr/bin/python3
-import sys
-import time
-
-print("Line1", file=sys.stderr)
-print("Line2", file=sys.stderr)
-print("Line3", file=sys.stderr)
-time.sleep(120)
-```
-
-It will register a command-based completion rule for a command such as `git`. The `complete` command should produce no output.
+It will register a command-based completion rule for a command such as `docker`. The `complete` command should produce no output.
 
 ```bash
-$ complete -C /path/to/completer_script git
+$ complete -C /path/to/completer_script docker
 $
 ```
 
-```bash
-# Expect: bell; standard error visible during completion; input line unchanged
-$ git <TAB>
+The tester will supply a completer script that prints nothing to the stdout. For example, the script might look something like this:
+
+```python
+#!/usr/bin/python3
+exit(0)
 ```
 
-The tester will verify that:
+```bash
+# Expect: bell only; input line unchanged
+$ docker xyz<TAB>
+```
 
-- The input line is unchanged after the tab press
-- That the bell character is not printed to standard output because the process have not completed yet and the shell cannot determine if completion candidates exist.
-- Text from the stderr of the completer appears on the terminal unchanged while the completer is still running.
+The tester will verify that the input line is unchanged after the tab press and that the bell character is printed to standard output.

--- a/stage_descriptions/programmable-completion-08-ep2.md
+++ b/stage_descriptions/programmable-completion-08-ep2.md
@@ -45,7 +45,7 @@ add  commit  push
 $ git 
 ```
 
-The tester will verify that all the completion options offered by the completer script are shown in the next line as completion options with at least two spaces in between, followed by the prompt from the previous line.
+The tester will verify that all the completion options offered by the completer script are shown in the next line as completion options with at least one space in between, followed by the prompt from the previous line.
 
 ### Notes
 

--- a/stage_descriptions/programmable-completion-10-tz2.md
+++ b/stage_descriptions/programmable-completion-10-tz2.md
@@ -14,16 +14,20 @@ The tester will execute your program like this:
 $ ./your_shell.sh
 ```
 
-It will register a completion, unregister it with `-r`, then attempt completion again.
+It will register a completion, unregister it with `-r`, confirm via `-p` that the rule is gone, then attempt completion again.
 
 ```bash
 $ complete -C '/path/to/completer/script' git
 $ complete -r git
+$ complete -p git
+complete: git: no completion specification
 # Expect: Bell to ring
 $ git <TAB>
 ```
 
-The tester will verify that after unregistering, tab completion for `git` no longer works and the bell rings.
+The tester will verify that:
+- `complete -p git` prints `complete: git: no completion specification` after unregistering
+- Tab completion for `git` no longer works and the bell rings
 
 ### Notes
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk because this PR only updates course YAML and stage markdown instructions/tests, but it may affect learner progression by changing stage order, difficulty, and exact expected outputs.
> 
> **Overview**
> Updates the *Programmable Completion* curriculum to change stage sequencing and expectations: `oi7` now focuses on `complete -p` printing the *missing specification* error, `wl6` combines `-C` registration with `-p` printing of registered specs, and the single-candidate completion behavior is moved into `pm5` while *no candidates → bell* is shifted to `qf1`.
> 
> Adjusts multiple stage writeups/tests accordingly (including adding a `complete -p` verification after `complete -r`, and relaxing the multi-candidate display spacing requirement from *at least two spaces* to *at least one space*).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ecd18b005890c8c502eb9642369c801c75d7993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->