### PR TITLE
Revise "Passing command-line arguments #zi0"

### DIFF
--- a/stage_descriptions/programmable-completion-06-zi0.md
+++ b/stage_descriptions/programmable-completion-06-zi0.md
@@ -29,7 +29,7 @@ The completer script can then use `argv[2]` to filter its candidates by prefix (
 The tester will execute your program like this:
 
 ```bash
-$ ./your_shell.sh
+$ ./your_program.sh
 ```
 
 It will register a completer script for a command:

--- a/stage_descriptions/programmable-completion-06-zi0.md
+++ b/stage_descriptions/programmable-completion-06-zi0.md
@@ -1,29 +1,28 @@
-In this stage, you'll pass completion context into a `-C` completer using the command-line arguments.
+In this stage, you'll pass completion context to a `-C` completer script as command-line arguments.
 
-### Passing arguments to the completer
+### Passing Arguments to the Completer
 
-In order for the completer script to know which completion candidates to offer for autocompletion, it must receive the context of what is being typed. So, when the shell runs a registered completer command, it invokes it with exactly three arguments, in this order:
+A completer script needs to know what the user is typing in order to offer relevant suggestions. When your shell invokes a completer registered with `complete -C`, it should pass exactly three arguments:
 
-1. `argv[1]` — The command name whose completion is active (the same name passed to `complete`, for example `git`).
+1. `argv[1]` — The command name being completed (e.g., `git`)
+2. `argv[2]` — The word currently being completed (the partial text at the cursor)
+3. `argv[3]` — The word immediately before the word being completed. If there's no preceding word, pass an empty string.
 
-2. `argv[2]` — the word currently being completed (the partial token the user is typing at the cursor).
+The completer script uses these values to decide which candidates to print to stdout (one per line, as before).
 
-3. `argv[3]` — the word immediately before the word being completed on the command line. If there is no preceding word, pass an empty string.
-
-The completer can use these values to decide what to print to stdout. Each line of stdout is still one completion candidate.
-
-For example, if the completer script is like this:
-
-```python
-# Write a simple completer script based on argv[2] with matching prefix
-# Must offer only for 'add cherry-pick commit push'
-```
+For example, given this command line:
 
 ```bash
-$ complete -C /path/to/completer_script git
-$ git cher<TAB>
-$ git cherry-pick 
+$ git remote set<TAB>
 ```
+
+Your shell should invoke the completer script with:
+
+- `argv[1]`: `git` (the command)
+- `argv[2]`: `set` (the word being completed)
+- `argv[3]`: `remote` (the previous word)
+
+The completer script can then use `argv[2]` to filter its candidates by prefix (e.g., returning `set-url` because it starts with `set`).
 
 ### Tests
 
@@ -33,19 +32,29 @@ The tester will execute your program like this:
 $ ./your_shell.sh
 ```
 
-It will register a command-based completion rule. The `complete` command should produce no output.
+It will register a completer script for a command:
 
 ```bash
 $ complete -C /path/to/completer_script git
-# Should autocomplete to remove followed by a trailing space
-$ git remote set<TAB>
-$ git remote set-url
 ```
 
-In the example above:
+It will then type a partial argument and press TAB:
 
-- `argv[1]`: `git` (Command)
-- `argv[2]`: `set` (Current word being completed)
-- `argv[3]`: `remote` (Previous word)
+```bash
+$ git remote set<TAB>
+$ git remote set-url 
+```
 
-The completer script will only work correctly if the proper values of `argv[1]`, `argv[2]`, and `argv[3]` are passed to the completer script.
+The completer script will only return the correct candidate if your shell passes the right values for `argv[1]`, `argv[2]`, and `argv[3]`.
+
+The tester will verify that:
+
+- The completer script receives the command name as `argv[1]`
+- The completer script receives the partial word being completed as `argv[2]`
+- The completer script receives the preceding word as `argv[3]`
+- The completed word replaces the partial text and a trailing space is added
+
+### Notes
+
+- The completer script is already written by the tester. You don't need to create it, just invoke it with the correct arguments.
+- If there's no word before the one being completed (e.g., `git <TAB>`), pass an empty string as `argv[3]`.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes that clarify expected behavior and test criteria; no code or runtime behavior is modified.
> 
> **Overview**
> Updates the `programmable-completion-06-zi0` stage documentation to more clearly specify the `complete -C` completer invocation contract, explicitly defining `argv[1]`/`argv[2]`/`argv[3]` and showing an end-to-end `git remote set<TAB>` example.
> 
> Clarifies the tester expectations (program name, required trailing space after completion, and what the provided completer script must receive), and adds notes about passing an empty `argv[3]` when there is no preceding word.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45eee8a4dec4c8be6c5690e0ebfd25e26af274cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->