### PR TITLE
Revise "Longest common prefix #xz3"

### DIFF
--- a/stage_descriptions/programmable-completion-09-xz3.md
+++ b/stage_descriptions/programmable-completion-09-xz3.md
@@ -20,7 +20,7 @@ If the candidates don't share a prefix beyond what's already typed, the behavior
 The tester will execute your program like this:
 
 ```bash
-$ ./your_shell.sh
+$ ./your_program.sh
 ```
 
 It will register a completer script that returns `checkout` and `cherry-pick`:

--- a/stage_descriptions/programmable-completion-09-xz3.md
+++ b/stage_descriptions/programmable-completion-09-xz3.md
@@ -1,18 +1,19 @@
-In this stage, you'll extend `-C` programmable completion using the longest common prefix (LCP) of the matching words.
+In this stage, you'll complete to the longest common prefix (LCP) when multiple candidates share one.
 
-### Longest common prefix for command-based completion
+### Longest Common Prefix Completion
 
-When multiple matches exist:
-- If they share a prefix longer than the current input: complete to the LCP
-- If they don't: ring the bell on the first tab, list matches on subsequent tab presses (like in previous stages)
+When a completer returns multiple candidates, there are two cases to handle:
 
-For example, if the completer script prints `checkout`, `cherry-pick`, on separate lines.
+If the candidates share a prefix longer than what the user has already typed, the first TAB should complete to that shared prefix without ringing the bell. For example, if the completer returns `checkout` and `cherry-pick` and the user has typed `c`:
 
 ```bash
-$ complete -C /path/to/completer_script git
-$ git ch<TAB>
+$ git c<TAB>
 $ git che
 ```
+
+Both candidates start with `che`, so the shell completes to `che` and waits for more input. No bell, no candidate list.
+
+If the candidates don't share a prefix beyond what's already typed, the behavior is the same as earlier stages: ring the bell on the first TAB, display candidates on the second.
 
 ### Tests
 
@@ -22,17 +23,23 @@ The tester will execute your program like this:
 $ ./your_shell.sh
 ```
 
-It will register a command-based completion rule for a command such as `git` and simulate tab presses on a partial subcommand. The completer script will print the same two newline-separated words as in the `-C` example above.
+It will register a completer script that returns `checkout` and `cherry-pick`:
 
 ```bash
 $ complete -C /path/to/completer_script git
-# Silent No output
 $ git c<TAB>
-# Extend to LCP 'che'
-# Because the options are: 'checkout' and 'cherry-pick'
-$ git che<TAB>
-# Press 'c' and press tab
-# Autocompletes to checkout with a trailing space
+$ git che                  # LCP of checkout and cherry-pick
 $ git chec<TAB>
-$ git checkout 
+$ git checkout             # only one match now, completes fully with trailing space
 ```
+
+The tester will verify that:
+
+- The first TAB completes to the longest common prefix when one exists
+- When only one candidate remains, TAB completes the full word with a trailing space
+- No bell rings when the LCP extends the current input
+
+### Notes
+
+- The LCP is computed from the candidates returned by the completer, not from a hardcoded list.
+- If the LCP is equal to what the user has already typed (no new characters to add), treat it the same as no common prefix: ring the bell and display candidates on the next TAB.

--- a/stage_descriptions/programmable-completion-09-xz3.md
+++ b/stage_descriptions/programmable-completion-09-xz3.md
@@ -4,7 +4,10 @@ In this stage, you'll complete to the longest common prefix (LCP) when multiple 
 
 When a completer returns multiple candidates, there are two cases to handle:
 
-If the candidates share a prefix longer than what the user has already typed, the first TAB should complete to that shared prefix without ringing the bell. For example, if the completer returns `checkout` and `cherry-pick` and the user has typed `c`:
+- If they share a prefix longer than the current input: complete to the LCP
+- If they don't: ring the bell on the first tab, list matches on subsequent tab presses (like in previous stages)
+
+For example, if the completer returns `checkout` and `cherry-pick` and the user has typed `c`:
 
 ```bash
 $ git c<TAB>
@@ -12,8 +15,6 @@ $ git che
 ```
 
 Both candidates start with `che`, so the shell completes to `che` and waits for more input. No bell, no candidate list.
-
-If the candidates don't share a prefix beyond what's already typed, the behavior is the same as earlier stages: ring the bell on the first TAB, display candidates on the second.
 
 ### Tests
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes that refine expected completion behavior and test assertions; no production code paths are modified.
> 
> **Overview**
> Updates the `programmable-completion-09-xz3` stage description to more clearly define *Longest Common Prefix* completion behavior when multiple candidates are returned.
> 
> Clarifies the test flow and expected UX: first TAB extends input to the LCP (with no bell/candidate list), subsequent completion when only one match remains adds a trailing space, and specifies the edge case where the LCP doesn’t extend the current input should behave like no common prefix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 986dd926099791d18d2bf7755d9809f2403541f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->