### PR TITLE
CC-2191: Upgrade Ruby to v4

### DIFF
--- a/compiled_starters/ruby/.codecrafters/run.sh
+++ b/compiled_starters/ruby/.codecrafters/run.sh
@@ -8,4 +8,5 @@
 
 set -e # Exit on failure
 
-exec bundle exec ruby app/main.rb "$@"
+export BUNDLE_GEMFILE="$(dirname "$0")/Gemfile"
+exec bundle exec ruby "$(dirname "$0")/app/main.rb" "$@"

--- a/compiled_starters/ruby/Gemfile.lock
+++ b/compiled_starters/ruby/Gemfile.lock
@@ -12,10 +12,12 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   readline
 
 BUNDLED WITH
-   2.5.10
+  4.0.10

--- a/compiled_starters/ruby/README.md
+++ b/compiled_starters/ruby/README.md
@@ -27,7 +27,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `ruby (3.4)` installed locally
+1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.rb`.
 1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test

--- a/compiled_starters/ruby/codecrafters.yml
+++ b/compiled_starters/ruby/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Ruby version used to run your code
 # on Codecrafters.
 #
-# Available versions: ruby-3.4
-buildpack: ruby-3.4
+# Available versions: ruby-4.0
+buildpack: ruby-4.0

--- a/compiled_starters/ruby/your_program.sh
+++ b/compiled_starters/ruby/your_program.sh
@@ -12,4 +12,5 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec bundle exec ruby app/main.rb "$@"
+export BUNDLE_GEMFILE="$(dirname "$0")/Gemfile"
+exec bundle exec ruby "$(dirname "$0")/app/main.rb" "$@"

--- a/dockerfiles/ruby-4.0.Dockerfile
+++ b/dockerfiles/ruby-4.0.Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM ruby:4.0-alpine3.23
+
+# Required for installing the json/async gems
+RUN apk add --no-cache \
+    build-base~=0.5 \
+    libssl3~=3.5 \
+    readline-dev~=8.3 \
+    zlib-dev~=1.3
+
+# Re-build if Gemfile or Gemfile.lock changes
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Gemfile,Gemfile.lock"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+RUN bundle install --verbose

--- a/solutions/ruby/01-oo8/code/.codecrafters/run.sh
+++ b/solutions/ruby/01-oo8/code/.codecrafters/run.sh
@@ -8,4 +8,5 @@
 
 set -e # Exit on failure
 
-exec bundle exec ruby app/main.rb "$@"
+export BUNDLE_GEMFILE="$(dirname "$0")/Gemfile"
+exec bundle exec ruby "$(dirname "$0")/app/main.rb" "$@"

--- a/solutions/ruby/01-oo8/code/Gemfile.lock
+++ b/solutions/ruby/01-oo8/code/Gemfile.lock
@@ -12,10 +12,12 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   readline
 
 BUNDLED WITH
-   2.5.10
+  4.0.10

--- a/solutions/ruby/01-oo8/code/README.md
+++ b/solutions/ruby/01-oo8/code/README.md
@@ -27,7 +27,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `ruby (3.4)` installed locally
+1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.rb`.
 1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test

--- a/solutions/ruby/01-oo8/code/codecrafters.yml
+++ b/solutions/ruby/01-oo8/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Ruby version used to run your code
 # on Codecrafters.
 #
-# Available versions: ruby-3.4
-buildpack: ruby-3.4
+# Available versions: ruby-4.0
+buildpack: ruby-4.0

--- a/solutions/ruby/01-oo8/code/your_program.sh
+++ b/solutions/ruby/01-oo8/code/your_program.sh
@@ -12,4 +12,5 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec bundle exec ruby app/main.rb "$@"
+export BUNDLE_GEMFILE="$(dirname "$0")/Gemfile"
+exec bundle exec ruby "$(dirname "$0")/app/main.rb" "$@"

--- a/solutions/ruby/02-cz2/code/.codecrafters/run.sh
+++ b/solutions/ruby/02-cz2/code/.codecrafters/run.sh
@@ -8,4 +8,5 @@
 
 set -e # Exit on failure
 
-exec bundle exec ruby app/main.rb "$@"
+export BUNDLE_GEMFILE="$(dirname "$0")/Gemfile"
+exec bundle exec ruby "$(dirname "$0")/app/main.rb" "$@"

--- a/solutions/ruby/02-cz2/code/Gemfile.lock
+++ b/solutions/ruby/02-cz2/code/Gemfile.lock
@@ -12,10 +12,12 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   readline
 
 BUNDLED WITH
-   2.5.10
+  4.0.10

--- a/solutions/ruby/02-cz2/code/README.md
+++ b/solutions/ruby/02-cz2/code/README.md
@@ -27,7 +27,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `ruby (3.4)` installed locally
+1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.rb`.
 1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test

--- a/solutions/ruby/02-cz2/code/codecrafters.yml
+++ b/solutions/ruby/02-cz2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Ruby version used to run your code
 # on Codecrafters.
 #
-# Available versions: ruby-3.4
-buildpack: ruby-3.4
+# Available versions: ruby-4.0
+buildpack: ruby-4.0

--- a/solutions/ruby/02-cz2/code/your_program.sh
+++ b/solutions/ruby/02-cz2/code/your_program.sh
@@ -12,4 +12,5 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec bundle exec ruby app/main.rb "$@"
+export BUNDLE_GEMFILE="$(dirname "$0")/Gemfile"
+exec bundle exec ruby "$(dirname "$0")/app/main.rb" "$@"

--- a/solutions/ruby/03-ff0/code/.codecrafters/run.sh
+++ b/solutions/ruby/03-ff0/code/.codecrafters/run.sh
@@ -8,4 +8,5 @@
 
 set -e # Exit on failure
 
-exec bundle exec ruby app/main.rb "$@"
+export BUNDLE_GEMFILE="$(dirname "$0")/Gemfile"
+exec bundle exec ruby "$(dirname "$0")/app/main.rb" "$@"

--- a/solutions/ruby/03-ff0/code/Gemfile.lock
+++ b/solutions/ruby/03-ff0/code/Gemfile.lock
@@ -12,10 +12,12 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   readline
 
 BUNDLED WITH
-   2.5.10
+  4.0.10

--- a/solutions/ruby/03-ff0/code/README.md
+++ b/solutions/ruby/03-ff0/code/README.md
@@ -27,7 +27,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `ruby (3.4)` installed locally
+1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.rb`.
 1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test

--- a/solutions/ruby/03-ff0/code/codecrafters.yml
+++ b/solutions/ruby/03-ff0/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Ruby version used to run your code
 # on Codecrafters.
 #
-# Available versions: ruby-3.4
-buildpack: ruby-3.4
+# Available versions: ruby-4.0
+buildpack: ruby-4.0

--- a/solutions/ruby/03-ff0/code/your_program.sh
+++ b/solutions/ruby/03-ff0/code/your_program.sh
@@ -12,4 +12,5 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec bundle exec ruby app/main.rb "$@"
+export BUNDLE_GEMFILE="$(dirname "$0")/Gemfile"
+exec bundle exec ruby "$(dirname "$0")/app/main.rb" "$@"

--- a/solutions/ruby/04-pn5/code/.codecrafters/run.sh
+++ b/solutions/ruby/04-pn5/code/.codecrafters/run.sh
@@ -8,4 +8,5 @@
 
 set -e # Exit on failure
 
-exec bundle exec ruby app/main.rb "$@"
+export BUNDLE_GEMFILE="$(dirname "$0")/Gemfile"
+exec bundle exec ruby "$(dirname "$0")/app/main.rb" "$@"

--- a/solutions/ruby/04-pn5/code/Gemfile.lock
+++ b/solutions/ruby/04-pn5/code/Gemfile.lock
@@ -12,10 +12,12 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   readline
 
 BUNDLED WITH
-   2.5.10
+  4.0.10

--- a/solutions/ruby/04-pn5/code/README.md
+++ b/solutions/ruby/04-pn5/code/README.md
@@ -27,7 +27,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `ruby (3.4)` installed locally
+1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.rb`.
 1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test

--- a/solutions/ruby/04-pn5/code/codecrafters.yml
+++ b/solutions/ruby/04-pn5/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Ruby version used to run your code
 # on Codecrafters.
 #
-# Available versions: ruby-3.4
-buildpack: ruby-3.4
+# Available versions: ruby-4.0
+buildpack: ruby-4.0

--- a/solutions/ruby/04-pn5/code/your_program.sh
+++ b/solutions/ruby/04-pn5/code/your_program.sh
@@ -12,4 +12,5 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec bundle exec ruby app/main.rb "$@"
+export BUNDLE_GEMFILE="$(dirname "$0")/Gemfile"
+exec bundle exec ruby "$(dirname "$0")/app/main.rb" "$@"

--- a/solutions/ruby/05-iz3/code/.codecrafters/run.sh
+++ b/solutions/ruby/05-iz3/code/.codecrafters/run.sh
@@ -8,4 +8,5 @@
 
 set -e # Exit on failure
 
-exec bundle exec ruby app/main.rb "$@"
+export BUNDLE_GEMFILE="$(dirname "$0")/Gemfile"
+exec bundle exec ruby "$(dirname "$0")/app/main.rb" "$@"

--- a/solutions/ruby/05-iz3/code/Gemfile.lock
+++ b/solutions/ruby/05-iz3/code/Gemfile.lock
@@ -12,10 +12,12 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   readline
 
 BUNDLED WITH
-   2.5.10
+  4.0.10

--- a/solutions/ruby/05-iz3/code/README.md
+++ b/solutions/ruby/05-iz3/code/README.md
@@ -27,7 +27,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `ruby (3.4)` installed locally
+1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.rb`.
 1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test

--- a/solutions/ruby/05-iz3/code/codecrafters.yml
+++ b/solutions/ruby/05-iz3/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Ruby version used to run your code
 # on Codecrafters.
 #
-# Available versions: ruby-3.4
-buildpack: ruby-3.4
+# Available versions: ruby-4.0
+buildpack: ruby-4.0

--- a/solutions/ruby/05-iz3/code/your_program.sh
+++ b/solutions/ruby/05-iz3/code/your_program.sh
@@ -12,4 +12,5 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec bundle exec ruby app/main.rb "$@"
+export BUNDLE_GEMFILE="$(dirname "$0")/Gemfile"
+exec bundle exec ruby "$(dirname "$0")/app/main.rb" "$@"

--- a/starter_templates/ruby/code/.codecrafters/run.sh
+++ b/starter_templates/ruby/code/.codecrafters/run.sh
@@ -8,4 +8,5 @@
 
 set -e # Exit on failure
 
-exec bundle exec ruby app/main.rb "$@"
+export BUNDLE_GEMFILE="$(dirname "$0")/Gemfile"
+exec bundle exec ruby "$(dirname "$0")/app/main.rb" "$@"

--- a/starter_templates/ruby/code/Gemfile.lock
+++ b/starter_templates/ruby/code/Gemfile.lock
@@ -12,10 +12,12 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   readline
 
 BUNDLED WITH
-   2.5.10
+  4.0.10

--- a/starter_templates/ruby/config.yml
+++ b/starter_templates/ruby/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: ruby (3.4)
+  required_executable: ruby (4.0)
   user_editable_file: app/main.rb


### PR DESCRIPTION
CC-2191: Upgrade Ruby to v4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves the Ruby runtime and Bundler versions forward (3.4→4.0), which can surface compatibility issues in gems and user submissions across environments. Low code complexity, but broad impact since it affects all Ruby starter/solution execution paths.
> 
> **Overview**
> Upgrades the Ruby track to **Ruby 4.0** by switching `codecrafters.yml` buildpacks from `ruby-3.4` to `ruby-4.0`, updating docs (`README.md`, `starter_templates/ruby/config.yml`) to require `ruby (4.0)`, and adding a new `dockerfiles/ruby-4.0.Dockerfile`.
> 
> Adjusts local/remote run scripts (`.codecrafters/run.sh`, `your_program.sh`) to set `BUNDLE_GEMFILE` and invoke `app/main.rb` via script-relative paths, and updates `Gemfile.lock` metadata (platforms + `BUNDLED WITH 4.0.10`) across starters and bundled solutions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17e80401ea98754fc91a4a0951d342c42b2fead5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->