### PR TITLE
Revise "Register complete builtin #ne7"

### DIFF
--- a/stage_descriptions/programmable-completion-01-ne7.md
+++ b/stage_descriptions/programmable-completion-01-ne7.md
@@ -1,36 +1,40 @@
-In this stage, you'll add support for the `complete` builtin.
+In this stage, you'll register `complete` as a shell builtin.
 
 ### The `complete` Builtin
 
-The [`complete`](https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html#index-complete) builtin lets the shell register and list programmable completions for commands.
+The [`complete`](https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html#index-complete) builtin lets users register programmable completions for commands.
 
-For example:
+For example, you can register a completer script for `git`:
 
 ```bash
-# Register the script as the completer script for the 'git' command
-$ complete -C /path/to/completer/script git
-# Make use of the registered completion
+$ complete -C /path/to/completer_script git
+```
+
+Once registered, the shell will invoke the script when the user presses TAB after `git` to get suggestions:
+
+```bash
 $ git clo<TAB>
-# Autocompletes to 'git clone'
 $ git clone 
 ```
+
+For this stage, you only need to register `complete` as a builtin so that it's recognized by the `type` command. We'll get to implementing the actual behavior in later stages.
 
 ### Tests
 
 The tester will execute your program like this:
 
 ```bash
-$ ./your_shell.sh
+$ ./your_program.sh
 ```
 
-It will then use the `type` builtin on `complete`
+It will then check that `complete` is recognized as a builtin:
 
 ```bash
-# Expect: complete is a shell builtin
 $ type complete
 complete is a shell builtin
 ```
 
 ### Notes
 
-- In this stage, you'll register `complete` as a builtin. You don't need to write the actual implementation of it yet. We'll get to that in the later stages.
+- You don't need to implement any completion logic in this stage. Just register `complete` so it shows up as a builtin.
+- If your shell already uses a list or map of builtins (e.g., `echo`, `cd`, `pwd`), you can add `complete` to that same structure.


### PR DESCRIPTION
Clarified the purpose of the `complete` builtin and updated examples for better understanding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust wording and examples without affecting runtime code.
> 
> **Overview**
> Updates the stage instructions for programmable completion to **focus solely on registering `complete` as a builtin** (so `type complete` reports it as a shell builtin), explicitly deferring any completion behavior to later stages.
> 
> Clarifies wording and refreshes examples/tests (e.g., `./your_program.sh`, simplified `git` TAB example, and additional notes on adding `complete` to the builtins list/map).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0a179d6049b03fd1ca25662620af62919761d58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->