### PR TITLE
Revise "Display registered completions"

### DIFF
--- a/stage_descriptions/programmable-completion-02-oi7.md
+++ b/stage_descriptions/programmable-completion-02-oi7.md
@@ -9,7 +9,7 @@ $ complete -p git
 complete: git: no completion specification
 ```
 
-For this stage, you can hardcode the error output. You don't need to track any specifications yet, just recognize `-p` and print the error message for whatever command name follows it.
+For this stage, you'll only return the error output. You don't need to track any specifications yet, just recognize `-p` and print the error message for whatever command name follows it.
 
 ### Tests
 
@@ -30,7 +30,3 @@ The tester will verify that:
 
 - The output matches the format `complete: <command>: no completion specification`
 - The command name in the output matches the one passed to `-p`
-
-### Notes
-
-- You can hardcode the output for this stage. We'll get to keeping track of completion specifications in the later stages.

--- a/stage_descriptions/programmable-completion-02-oi7.md
+++ b/stage_descriptions/programmable-completion-02-oi7.md
@@ -2,7 +2,14 @@ In this stage, you'll add support for the `-p` flag on the `complete` builtin.
 
 ### The `-p` Flag
 
-The `-p` flag prints the completion specification registered for a given command. When no specification has been registered, it prints an error message in this format:
+The `-p` flag prints the completion specification registered for a given command. 
+
+```bash
+$ complete -p git
+complete -C '/path/to/git/completer' git
+```
+
+When no specification has been registered, it prints an error message in this format:
 
 ```bash
 $ complete -p git

--- a/stage_descriptions/programmable-completion-02-oi7.md
+++ b/stage_descriptions/programmable-completion-02-oi7.md
@@ -1,33 +1,35 @@
-In this stage, you'll add support for the `-p` flag for the `complete` builtin.
+In this stage, you'll add support for the `-p` flag on the `complete` builtin.
 
-### The `-p` flag
+### The `-p` Flag
 
-The `-p` flag prints the completion specification registered for a given command in a reusable format.
-
-If no specification has been registered, the shell prints an error message indicating there's no completion specification for that command.
-
-For example:
+The `-p` flag prints the completion specification registered for a given command. When no specification has been registered, it prints an error message in this format:
 
 ```bash
-# See the autocompletion specification for the 'git' command
 $ complete -p git
 complete: git: no completion specification
 ```
+
+For this stage, you can hardcode the error output. You don't need to track any specifications yet, just recognize `-p` and print the error message for whatever command name follows it.
 
 ### Tests
 
 The tester will execute your program like this:
 
 ```bash
-$ ./your_shell.sh
+$ ./your_program.sh
 ```
 
-It will then use the `-p` flag with the `complete` builtin.
+It will run `complete -p` with a random command name:
 
 ```bash
-$ complete -p git
-complete: git: no completion specification
+$ complete -p <command>
+complete: <command>: no completion specification
 ```
+
+The tester will verify that:
+
+- The output matches the format `complete: <command>: no completion specification`
+- The command name in the output matches the one passed to `-p`
 
 ### Notes
 


### PR DESCRIPTION
Updated the description and formatting for the `-p` flag in the `complete` builtin documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies expected output and test invocation without modifying runtime code paths.
> 
> **Overview**
> Updates the stage documentation for programmable completion to better define `complete -p` behavior and expected error output format.
> 
> Clarifies test execution details (uses `./your_program.sh`, random `<command>` input) and explicitly lists the assertions the tester will check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b3ec509fecf3afeeb5a95eaf9185003e9bcd05e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->