### PR TITLE
Revise "Handling no completions #qf1"

### DIFF
--- a/stage_descriptions/programmable-completion-05-qf1.md
+++ b/stage_descriptions/programmable-completion-05-qf1.md
@@ -1,17 +1,27 @@
-In this stage, you'll handle the case where the completer produces no completion candidates.
+In this stage, you'll handle the case where the completer script returns no candidates.
 
-### No completion candidates
+### Handling Empty Completer Output
 
-When the user presses tab and the shell runs the registered completer script, the shell reads standard output and treats line as a candidate. If the completer prints nothing to standard output, there are no candidates to apply.
+When the completer script prints nothing to stdout, your shell has no candidates to work with. In that case, the shell should:
 
-In that case the shell should not insert text or replace the current word. It should print the bell character (`\x07`) to standard output.
+- Not insert or modify any text
+- Ring the terminal bell by printing `\x07` to stdout
 
-For example:
+This gives the user feedback that their TAB press was received but no completion was available.
+
+For example, a completer that always exits without printing anything:
+
+```python
+#!/usr/bin/env python3
+exit(0)
+```
+
+When registered and triggered with TAB, your shell should just ring the bell and leave the input untouched:
 
 ```bash
 $ complete -C /path/to/completer_script docker
 $ docker xyz<TAB>
-# Bell (\x07); line unchanged
+# bell rings, input line stays as "docker xyz"
 ```
 
 ### Tests
@@ -19,26 +29,18 @@ $ docker xyz<TAB>
 The tester will execute your program like this:
 
 ```bash
-$ ./your_shell.sh
+$ ./your_program.sh
 ```
 
-It will register a command-based completion rule for a command such as `docker`. The `complete` command should produce no output.
+It will supply a completer script that prints nothing, register it for a command, and press TAB:
 
 ```bash
-$ complete -C /path/to/completer_script docker
-$
+$ complete -C /path/to/completer_script <command>
+$ <command> <partial><TAB>
+# bell rings, input unchanged
 ```
 
-The tester will supply a completer script that prints nothing to the stdout. For example, the script might look something like this:
+The tester will verify that:
 
-```python
-#!/usr/bin/python3
-exit(0)
-```
-
-```bash
-# Expect: bell only; input line unchanged
-$ docker xyz<TAB>
-```
-
-The tester will verify that the input line is unchanged after the tab press and that the bell character is printed to standard output.
+- The input line is unchanged after the TAB press
+- The bell character (`\x07`) is printed to stdout

--- a/stage_descriptions/programmable-completion-05-qf1.md
+++ b/stage_descriptions/programmable-completion-05-qf1.md
@@ -4,7 +4,7 @@ In this stage, you'll handle the case where the completer script returns no cand
 
 When the completer script prints nothing to stdout, your shell has no candidates to work with. In that case, the shell should:
 
-- Not insert or modify any text
+- Leave the input unchanged
 - Ring the terminal bell by printing `\x07` to stdout
 
 This gives the user feedback that their TAB press was received but no completion was available.
@@ -35,8 +35,8 @@ $ ./your_program.sh
 It will supply a completer script that prints nothing, register it for a command, and press TAB:
 
 ```bash
-$ complete -C /path/to/completer_script <command>
-$ <command> <partial><TAB>
+$ complete -C /path/to/completer_script docker
+$ docker xyz<TAB>
 # bell rings, input unchanged
 ```
 


### PR DESCRIPTION
Updated the stage description to clarify handling of empty completer output, including specific actions the shell should take when no candidates are available.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that clarify expected behavior and tester wording; no runtime code or security-sensitive logic is modified.
> 
> **Overview**
> Clarifies the programmable completion stage behavior when a completer returns *no output*: the shell must **leave the input unchanged** and **ring the terminal bell** by printing `\x07` to stdout.
> 
> Updates examples and test expectations accordingly (including the invocation name `./your_program.sh`) and adds a minimal “empty completer” script snippet to make the scenario explicit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d37f1594588f31091a9757057acbb6b6e5f6dca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->