### PR TITLE
Clarify quoting rules in #tg6 Double quotes

### DIFF
--- a/stage_descriptions/quoting-02-tg6.md
+++ b/stage_descriptions/quoting-02-tg6.md
@@ -9,6 +9,7 @@ For this stage, your shell must apply the following rules when parsing double qu
 - Consecutive whitespaces (spaces, tabs) must be preserved.
 - Characters that normally act as delimiters or special characters lose their special meaning inside double quotes and are treated literally.
 - Double-quoted strings placed next to each other are concatenated to form a single argument.
+    - Quoted and unquoted strings placed next to each other are also concatenated.
 
 For example:
 
@@ -18,6 +19,9 @@ hello    world         # Multiple spaces preserved
 
 $ echo "hello""world"
 helloworld             # Quoted strings next to each other are concatenated.
+
+$ echo "hello"world
+helloworld             # Quoted and unquoted strings next to each other are concatenated.
 
 $ echo "hello" "world"
 hello world            # Separate arguments


### PR DESCRIPTION
Context:

https://secure.helpscout.net/conversation/3297276435/12716#thread-10054860293

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies parsing rules; no code behavior changes, so risk is limited to potential spec/test interpretation by learners.
> 
> **Overview**
> Clarifies the `#tg6` double-quote parsing rules to explicitly state that *adjacent quoted and unquoted text is concatenated into a single argument*.
> 
> Adds a concrete `echo "hello"world` example demonstrating this behavior alongside the existing adjacent-quote concatenation example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a346335f5f63172435f32d42ded14ae1422973d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->