### PR TITLE
Update example commands to match tester #ny9

### DIFF
--- a/stage_descriptions/pipelines-02-ny9.md
+++ b/stage_descriptions/pipelines-02-ny9.md
@@ -13,8 +13,8 @@ The tester will execute your program like this:
 It'll then send commands involving pipelines with built-ins:
 
 ```bash
-$ echo raspberry\\nblueberry | wc
-       1       1      20
+$ echo apple-orange | wc
+       1       1      13
 $ ls | type exit
 exit is a shell builtin
 $


### PR DESCRIPTION
Context:

https://forum.codecrafters.io/t/how-does-this-count-as-20-characters-and-1-line-at-the-same-time/16081

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that updates the example command/output expected by the tester, with no runtime code impact.
> 
> **Overview**
> Updates the pipeline stage documentation example to use `echo apple-orange | wc` (with the corrected `wc` output) instead of the previous multi-line `echo` input, aligning the instructions with the current tester expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97edeef75307ee41bdfd186a8896da25b524f4fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->