### PR TITLE
Update difficulty level for #nr7 "Passing environment variables"

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -484,7 +484,7 @@ stages:
   - slug: "nr7"
     primary_extension_slug: "programmable-completion"
     name: "Passing environment variables"
-    difficulty: medium
+    difficulty: easy
     marketing_md: |-
       In this stage, you'll pass completion context into a `-C` completer using environment variables.
 


### PR DESCRIPTION
Context:

<img width="512" alt="image" src="https://github.com/user-attachments/assets/2dac62b6-2e62-4823-8060-e5728970e295" />


Thanks to @anviks for highlighting the issue!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that only affects how the `nr7` stage is labeled/ordered by difficulty, with no runtime or content logic impact.
> 
> **Overview**
> Updates the `shell` course definition to change stage `nr7` ("Passing environment variables") difficulty from **medium** to **easy**, aligning the stage’s displayed difficulty with expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b6884ff64baa57604b15ab962c6b0207036579e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->