### PR TITLE
Update Zig 0.16 Dockerfile to include procps for shell/background jobs

### DIFF
--- a/dockerfiles/zig-0.16.Dockerfile
+++ b/dockerfiles/zig-0.16.Dockerfile
@@ -1,13 +1,14 @@
 # syntax=docker/dockerfile:1.7-labs
 FROM debian:trixie
 
+# procps: shell / background-jobs
 # hadolint ignore=DL3008
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
         curl \
         xz-utils \
-        && \
-    apt-get clean && \
+        procps \
+    && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Download and install Zig


### PR DESCRIPTION
Context:

https://forum.codecrafters.io/t/problem-with-starting-background-job-at7/16095

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to the Docker image build: it adds the `procps` package to support process/background job utilities, with no application logic changes.
> 
> **Overview**
> Updates the Zig 0.16 Docker image to install `procps` (alongside `curl`/`xz-utils`) so the container includes standard process utilities needed for shell/background jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1996e3a60cecee6f90c8ae47dabb87d8b97be657. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->