### PR TITLE
CC-2274: Upgrade Gleam to v1.16

### DIFF
--- a/compiled_starters/gleam/.codecrafters/compile.sh
+++ b/compiled_starters/gleam/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/compiled_starters/gleam/.codecrafters/run.sh
+++ b/compiled_starters/gleam/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/compiled_starters/gleam/.gitignore
+++ b/compiled_starters/gleam/.gitignore
@@ -2,3 +2,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/compiled_starters/gleam/codecrafters.yml
+++ b/compiled_starters/gleam/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Gleam version used to run your code
 # on Codecrafters.
 #
-# Available versions: gleam-1.14
-buildpack: gleam-1.14
+# Available versions: gleam-1.16
+buildpack: gleam-1.16

--- a/compiled_starters/gleam/gleam.toml
+++ b/compiled_starters/gleam/gleam.toml
@@ -1,12 +1,13 @@
-name = "codecrafters_shell"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
-gleam_erlang = ">= 0.33.0 and < 1.0.0"
+gleam_stdlib = ">= 1.0.0 and < 2.0.0"
+gleam_erlang = ">= 1.3.0 and < 2.0.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/compiled_starters/gleam/manifest.toml
+++ b/compiled_starters/gleam/manifest.toml
@@ -2,12 +2,20 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
-  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleescript", version = "1.5.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "27AC58481742ED29D9B37C506F78958A8AD798750A79ED08C8F8AFBA8F23563B" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
 [requirements]
-gleam_erlang = { version = ">= 0.33.0 and < 1.0.0" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 1.0.0 and < 2.0.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/compiled_starters/gleam/your_program.sh
+++ b/compiled_starters/gleam/your_program.sh
@@ -15,10 +15,11 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   gleam build
+  gleam run -m gleescript
 )
 
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/dockerfiles/gleam-1.16.Dockerfile
+++ b/dockerfiles/gleam-1.16.Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM ghcr.io/gleam-lang/gleam:v1.16.0-erlang-alpine
+
+# Rebuild if gleam.toml or manifest.toml change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="gleam.toml,manifest.toml"
+
+RUN apk add --no-cache \
+    build-base~=0.5
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# Force deps to be downloaded
+RUN gleam build
+
+# Cache build directory
+RUN mkdir -p /app-cached
+RUN mv build /app-cached/build

--- a/solutions/gleam/01-oo8/code/.codecrafters/compile.sh
+++ b/solutions/gleam/01-oo8/code/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/solutions/gleam/01-oo8/code/.codecrafters/run.sh
+++ b/solutions/gleam/01-oo8/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/solutions/gleam/01-oo8/code/.gitignore
+++ b/solutions/gleam/01-oo8/code/.gitignore
@@ -2,3 +2,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/solutions/gleam/01-oo8/code/codecrafters.yml
+++ b/solutions/gleam/01-oo8/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Gleam version used to run your code
 # on Codecrafters.
 #
-# Available versions: gleam-1.14
-buildpack: gleam-1.14
+# Available versions: gleam-1.16
+buildpack: gleam-1.16

--- a/solutions/gleam/01-oo8/code/gleam.toml
+++ b/solutions/gleam/01-oo8/code/gleam.toml
@@ -1,12 +1,13 @@
-name = "codecrafters_shell"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
-gleam_erlang = ">= 0.33.0 and < 1.0.0"
+gleam_stdlib = ">= 1.0.0 and < 2.0.0"
+gleam_erlang = ">= 1.3.0 and < 2.0.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/solutions/gleam/01-oo8/code/manifest.toml
+++ b/solutions/gleam/01-oo8/code/manifest.toml
@@ -2,12 +2,20 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
-  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleescript", version = "1.5.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "27AC58481742ED29D9B37C506F78958A8AD798750A79ED08C8F8AFBA8F23563B" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
 [requirements]
-gleam_erlang = { version = ">= 0.33.0 and < 1.0.0" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 1.0.0 and < 2.0.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/solutions/gleam/01-oo8/code/your_program.sh
+++ b/solutions/gleam/01-oo8/code/your_program.sh
@@ -15,10 +15,11 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   gleam build
+  gleam run -m gleescript
 )
 
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/solutions/gleam/02-cz2/code/.codecrafters/compile.sh
+++ b/solutions/gleam/02-cz2/code/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/solutions/gleam/02-cz2/code/.codecrafters/run.sh
+++ b/solutions/gleam/02-cz2/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/solutions/gleam/02-cz2/code/.gitignore
+++ b/solutions/gleam/02-cz2/code/.gitignore
@@ -2,3 +2,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/solutions/gleam/02-cz2/code/codecrafters.yml
+++ b/solutions/gleam/02-cz2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Gleam version used to run your code
 # on Codecrafters.
 #
-# Available versions: gleam-1.14
-buildpack: gleam-1.14
+# Available versions: gleam-1.16
+buildpack: gleam-1.16

--- a/solutions/gleam/02-cz2/code/gleam.toml
+++ b/solutions/gleam/02-cz2/code/gleam.toml
@@ -1,12 +1,13 @@
-name = "codecrafters_shell"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
-gleam_erlang = ">= 0.33.0 and < 1.0.0"
+gleam_stdlib = ">= 1.0.0 and < 2.0.0"
+gleam_erlang = ">= 1.3.0 and < 2.0.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/solutions/gleam/02-cz2/code/manifest.toml
+++ b/solutions/gleam/02-cz2/code/manifest.toml
@@ -2,12 +2,20 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
-  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleescript", version = "1.5.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "27AC58481742ED29D9B37C506F78958A8AD798750A79ED08C8F8AFBA8F23563B" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
 [requirements]
-gleam_erlang = { version = ">= 0.33.0 and < 1.0.0" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 1.0.0 and < 2.0.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/solutions/gleam/02-cz2/code/src/main.gleam
+++ b/solutions/gleam/02-cz2/code/src/main.gleam
@@ -1,11 +1,13 @@
 import gleam/io
-import gleam/erlang
 import gleam/string
 
 pub fn main() {
   io.print("$ ")
-  let assert Ok(command) = erlang.get_line("") 
-  
-  let cmd = string.trim(command)
-  io.println(cmd <> ": command not found")
+  let input_line = get_line("")
+
+  let command = string.trim(input_line)
+  io.println(command <> ": command not found")
 }
+
+@external(erlang, "io", "get_line")
+fn get_line(prompt prompt: String) -> String

--- a/solutions/gleam/02-cz2/code/your_program.sh
+++ b/solutions/gleam/02-cz2/code/your_program.sh
@@ -15,10 +15,11 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   gleam build
+  gleam run -m gleescript
 )
 
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/solutions/gleam/02-cz2/config.yml
+++ b/solutions/gleam/02-cz2/config.yml
@@ -1,13 +1,14 @@
 hints:
   - title_markdown: "How do I read the user's command?"
     body_markdown: |-
-      Use the [`get_line()`](https://hexdocs.pm/gleam_stdlib/gleam/erlang.html#get_line) function:
+      Use the [`get_line()`](https://www.erlang.org/doc/apps/stdlib/io.html#get_line/1) function:
 
       ```gleam
-      import gleam/erlang
+      @external(erlang, "io", "get_line")
+      fn get_line(prompt: String) -> String
 
       // Captures the user's command
-      let assert Ok(command) = erlang.get_line("")
+      let input_line = get_line("")
       ```
 
       The `get_line()` function waits for the user to enter a command and returns it as a string (including a trailing newline).
@@ -16,12 +17,13 @@ hints:
       Use the [`println()`](https://hexdocs.pm/gleam_stdlib/gleam/io.html#println) function:
 
       ```gleam
+      import gleam/io
       import gleam/string
 
       # Prints the "<command>: command not found" message
-      let cmd = string.trim(command)
-      io.println(cmd <> ": command not found")
+      let command = string.trim(input_line)
+      io.println(command <> ": command not found")
       ```
 
       - The `<>` operator concatenates strings.
-      - The `string.trim()` function removes surrounding whitespace, including the trailing newline from `command`.
+      - The `string.trim()` function removes surrounding whitespace, including the trailing newline from `input_line`.

--- a/solutions/gleam/02-cz2/diff/src/main.gleam.diff
+++ b/solutions/gleam/02-cz2/diff/src/main.gleam.diff
@@ -1,12 +1,14 @@
-@@ -1,5 +1,11 @@
+@@ -1,5 +1,13 @@
  import gleam/io
-+import gleam/erlang
 +import gleam/string
 
  pub fn main() {
    io.print("$ ")
-+  let assert Ok(command) = erlang.get_line("") 
-+  
-+  let cmd = string.trim(command)
-+  io.println(cmd <> ": command not found")
++  let input_line = get_line("")
++
++  let command = string.trim(input_line)
++  io.println(command <> ": command not found")
  }
++
++@external(erlang, "io", "get_line")
++fn get_line(prompt prompt: String) -> String

--- a/solutions/gleam/03-ff0/code/.codecrafters/compile.sh
+++ b/solutions/gleam/03-ff0/code/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/solutions/gleam/03-ff0/code/.codecrafters/run.sh
+++ b/solutions/gleam/03-ff0/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/solutions/gleam/03-ff0/code/.gitignore
+++ b/solutions/gleam/03-ff0/code/.gitignore
@@ -2,3 +2,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/solutions/gleam/03-ff0/code/codecrafters.yml
+++ b/solutions/gleam/03-ff0/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Gleam version used to run your code
 # on Codecrafters.
 #
-# Available versions: gleam-1.14
-buildpack: gleam-1.14
+# Available versions: gleam-1.16
+buildpack: gleam-1.16

--- a/solutions/gleam/03-ff0/code/gleam.toml
+++ b/solutions/gleam/03-ff0/code/gleam.toml
@@ -1,12 +1,13 @@
-name = "codecrafters_shell"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
-gleam_erlang = ">= 0.33.0 and < 1.0.0"
+gleam_stdlib = ">= 1.0.0 and < 2.0.0"
+gleam_erlang = ">= 1.3.0 and < 2.0.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/solutions/gleam/03-ff0/code/manifest.toml
+++ b/solutions/gleam/03-ff0/code/manifest.toml
@@ -2,12 +2,20 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
-  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleescript", version = "1.5.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "27AC58481742ED29D9B37C506F78958A8AD798750A79ED08C8F8AFBA8F23563B" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
 [requirements]
-gleam_erlang = { version = ">= 0.33.0 and < 1.0.0" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 1.0.0 and < 2.0.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/solutions/gleam/03-ff0/code/src/main.gleam
+++ b/solutions/gleam/03-ff0/code/src/main.gleam
@@ -1,12 +1,14 @@
 import gleam/io
-import gleam/erlang
 import gleam/string
 
 pub fn main() {
   io.print("$ ")
-  let assert Ok(command) = erlang.get_line("")
+  let input_line = get_line("")
 
-  let cmd = string.trim(command)
-  io.println(cmd <> ": command not found")
+  let command = string.trim(input_line)
+  io.println(command <> ": command not found")
   main()
 }
+
+@external(erlang, "io", "get_line")
+fn get_line(prompt prompt: String) -> String

--- a/solutions/gleam/03-ff0/code/your_program.sh
+++ b/solutions/gleam/03-ff0/code/your_program.sh
@@ -15,10 +15,11 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   gleam build
+  gleam run -m gleescript
 )
 
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/solutions/gleam/03-ff0/diff/src/main.gleam.diff
+++ b/solutions/gleam/03-ff0/diff/src/main.gleam.diff
@@ -1,15 +1,15 @@
-@@ -1,11 +1,12 @@
+@@ -1,13 +1,14 @@
  import gleam/io
- import gleam/erlang
  import gleam/string
 
  pub fn main() {
    io.print("$ ")
--  let assert Ok(command) = erlang.get_line("") 
--  
-+  let assert Ok(command) = erlang.get_line("")
-+
-   let cmd = string.trim(command)
-   io.println(cmd <> ": command not found")
+   let input_line = get_line("")
+
+   let command = string.trim(input_line)
+   io.println(command <> ": command not found")
 +  main()
  }
+
+ @external(erlang, "io", "get_line")
+ fn get_line(prompt prompt: String) -> String

--- a/solutions/gleam/04-pn5/code/.codecrafters/compile.sh
+++ b/solutions/gleam/04-pn5/code/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/solutions/gleam/04-pn5/code/.codecrafters/run.sh
+++ b/solutions/gleam/04-pn5/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/solutions/gleam/04-pn5/code/.gitignore
+++ b/solutions/gleam/04-pn5/code/.gitignore
@@ -2,3 +2,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/solutions/gleam/04-pn5/code/codecrafters.yml
+++ b/solutions/gleam/04-pn5/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Gleam version used to run your code
 # on Codecrafters.
 #
-# Available versions: gleam-1.14
-buildpack: gleam-1.14
+# Available versions: gleam-1.16
+buildpack: gleam-1.16

--- a/solutions/gleam/04-pn5/code/gleam.toml
+++ b/solutions/gleam/04-pn5/code/gleam.toml
@@ -1,12 +1,13 @@
-name = "codecrafters_shell"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
-gleam_erlang = ">= 0.33.0 and < 1.0.0"
+gleam_stdlib = ">= 1.0.0 and < 2.0.0"
+gleam_erlang = ">= 1.3.0 and < 2.0.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/solutions/gleam/04-pn5/code/manifest.toml
+++ b/solutions/gleam/04-pn5/code/manifest.toml
@@ -2,12 +2,20 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
-  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleescript", version = "1.5.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "27AC58481742ED29D9B37C506F78958A8AD798750A79ED08C8F8AFBA8F23563B" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
 [requirements]
-gleam_erlang = { version = ">= 0.33.0 and < 1.0.0" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 1.0.0 and < 2.0.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/solutions/gleam/04-pn5/code/src/main.gleam
+++ b/solutions/gleam/04-pn5/code/src/main.gleam
@@ -1,17 +1,19 @@
 import gleam/io
-import gleam/erlang
 import gleam/string
 
 pub fn main() {
   io.print("$ ")
-  let assert Ok(command) = erlang.get_line("")
+  let input_line = get_line("")
 
-  let cmd = string.trim(command)
-  case cmd {
+  let command = string.trim(input_line)
+  case command {
     "exit" -> Nil
     _ -> {
-      io.println(cmd <> ": command not found")
+      io.println(command <> ": command not found")
       main()
     }
   }
 }
+
+@external(erlang, "io", "get_line")
+fn get_line(prompt prompt: String) -> String

--- a/solutions/gleam/04-pn5/code/your_program.sh
+++ b/solutions/gleam/04-pn5/code/your_program.sh
@@ -15,10 +15,11 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   gleam build
+  gleam run -m gleescript
 )
 
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/solutions/gleam/04-pn5/config.yml
+++ b/solutions/gleam/04-pn5/config.yml
@@ -3,7 +3,7 @@ hints:
     body_markdown: |-
       Use a `case` expression to check if the command is `exit`:
       ```gleam
-      case cmd {
+      case command {
         "exit" -> // Exit the shell
         _ -> // Handle other commands
       }
@@ -15,10 +15,10 @@ hints:
     body_markdown: |-
       Return `Nil` instead of recursing to terminate the program:
       ```gleam
-      case cmd {
+      case command {
         "exit" -> Nil
         _ -> {
-          io.println(cmd <> ": command not found")
+          io.println(command <> ": command not found")
           main()
         }
       }

--- a/solutions/gleam/04-pn5/diff/src/main.gleam.diff
+++ b/solutions/gleam/04-pn5/diff/src/main.gleam.diff
@@ -1,20 +1,22 @@
-@@ -1,12 +1,17 @@
+@@ -1,14 +1,19 @@
  import gleam/io
- import gleam/erlang
  import gleam/string
 
  pub fn main() {
    io.print("$ ")
-   let assert Ok(command) = erlang.get_line("")
+   let input_line = get_line("")
 
-   let cmd = string.trim(command)
--  io.println(cmd <> ": command not found")
+   let command = string.trim(input_line)
+-  io.println(command <> ": command not found")
 -  main()
-+  case cmd {
++  case command {
 +    "exit" -> Nil
 +    _ -> {
-+      io.println(cmd <> ": command not found")
++      io.println(command <> ": command not found")
 +      main()
 +    }
 +  }
  }
+
+ @external(erlang, "io", "get_line")
+ fn get_line(prompt prompt: String) -> String

--- a/solutions/gleam/05-iz3/code/.codecrafters/compile.sh
+++ b/solutions/gleam/05-iz3/code/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/solutions/gleam/05-iz3/code/.codecrafters/run.sh
+++ b/solutions/gleam/05-iz3/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/solutions/gleam/05-iz3/code/.gitignore
+++ b/solutions/gleam/05-iz3/code/.gitignore
@@ -2,3 +2,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/solutions/gleam/05-iz3/code/codecrafters.yml
+++ b/solutions/gleam/05-iz3/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Gleam version used to run your code
 # on Codecrafters.
 #
-# Available versions: gleam-1.14
-buildpack: gleam-1.14
+# Available versions: gleam-1.16
+buildpack: gleam-1.16

--- a/solutions/gleam/05-iz3/code/gleam.toml
+++ b/solutions/gleam/05-iz3/code/gleam.toml
@@ -1,12 +1,13 @@
-name = "codecrafters_shell"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
-gleam_erlang = ">= 0.33.0 and < 1.0.0"
+gleam_stdlib = ">= 1.0.0 and < 2.0.0"
+gleam_erlang = ">= 1.3.0 and < 2.0.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/solutions/gleam/05-iz3/code/manifest.toml
+++ b/solutions/gleam/05-iz3/code/manifest.toml
@@ -2,12 +2,20 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
-  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleescript", version = "1.5.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "27AC58481742ED29D9B37C506F78958A8AD798750A79ED08C8F8AFBA8F23563B" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
 [requirements]
-gleam_erlang = { version = ">= 0.33.0 and < 1.0.0" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 1.0.0 and < 2.0.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/solutions/gleam/05-iz3/code/src/main.gleam
+++ b/solutions/gleam/05-iz3/code/src/main.gleam
@@ -1,21 +1,23 @@
 import gleam/io
-import gleam/erlang
 import gleam/string
 
 pub fn main() {
   io.print("$ ")
-  let assert Ok(command) = erlang.get_line("")
+  let input_line = get_line("")
 
-  let cmd = string.trim(command)
-  case cmd {
+  let command = string.trim(input_line)
+  case command {
     "exit" -> Nil
     "echo " <> rest -> {
       io.println(rest)
       main()
     }
     _ -> {
-      io.println(cmd <> ": command not found")
+      io.println(command <> ": command not found")
       main()
     }
   }
 }
+
+@external(erlang, "io", "get_line")
+fn get_line(prompt prompt: String) -> String

--- a/solutions/gleam/05-iz3/code/your_program.sh
+++ b/solutions/gleam/05-iz3/code/your_program.sh
@@ -15,10 +15,11 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   gleam build
+  gleam run -m gleescript
 )
 
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/solutions/gleam/05-iz3/config.yml
+++ b/solutions/gleam/05-iz3/config.yml
@@ -3,7 +3,7 @@ hints:
     body_markdown: |-
       Use pattern matching with the `<>` operator to check if the command starts with `echo `:
       ```gleam
-      case cmd {
+      case command {
         "echo " <> rest -> // Handle the echo command
         _ -> // Handle other commands
       }
@@ -15,7 +15,7 @@ hints:
     body_markdown: |-
       The `<>` pattern operator automatically captures the rest of the string:
       ```gleam
-      case cmd {
+      case command {
         "echo " <> rest -> {
           io.println(rest)
           main()

--- a/solutions/gleam/05-iz3/diff/src/main.gleam.diff
+++ b/solutions/gleam/05-iz3/diff/src/main.gleam.diff
@@ -1,22 +1,24 @@
-@@ -1,17 +1,21 @@
+@@ -1,19 +1,23 @@
  import gleam/io
- import gleam/erlang
  import gleam/string
 
  pub fn main() {
    io.print("$ ")
-   let assert Ok(command) = erlang.get_line("")
+   let input_line = get_line("")
 
-   let cmd = string.trim(command)
-   case cmd {
+   let command = string.trim(input_line)
+   case command {
      "exit" -> Nil
 +    "echo " <> rest -> {
 +      io.println(rest)
 +      main()
 +    }
      _ -> {
-       io.println(cmd <> ": command not found")
+       io.println(command <> ": command not found")
        main()
      }
    }
  }
+
+ @external(erlang, "io", "get_line")
+ fn get_line(prompt prompt: String) -> String

--- a/starter_templates/gleam/code/.codecrafters/compile.sh
+++ b/starter_templates/gleam/code/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/starter_templates/gleam/code/.codecrafters/run.sh
+++ b/starter_templates/gleam/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/starter_templates/gleam/code/.gitignore
+++ b/starter_templates/gleam/code/.gitignore
@@ -2,3 +2,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/starter_templates/gleam/code/gleam.toml
+++ b/starter_templates/gleam/code/gleam.toml
@@ -1,12 +1,13 @@
-name = "codecrafters_shell"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
-gleam_erlang = ">= 0.33.0 and < 1.0.0"
+gleam_stdlib = ">= 1.0.0 and < 2.0.0"
+gleam_erlang = ">= 1.3.0 and < 2.0.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/starter_templates/gleam/code/manifest.toml
+++ b/starter_templates/gleam/code/manifest.toml
@@ -2,12 +2,20 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
-  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleescript", version = "1.5.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "27AC58481742ED29D9B37C506F78958A8AD798750A79ED08C8F8AFBA8F23563B" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
 [requirements]
-gleam_erlang = { version = ">= 0.33.0 and < 1.0.0" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 1.0.0 and < 2.0.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the Gleam toolchain/version and the compile/run pipeline (introducing `gleescript` and a new `main` executable), which could break builds or runtime invocation across environments.
> 
> **Overview**
> Upgrades the Gleam track to `gleam-1.16` and updates `gleam.toml`/`manifest.toml` dependency constraints accordingly, adding `gleescript` as a dev dependency.
> 
> Changes CodeCrafters and local scripts to build an executable (`gleam run -m gleescript`) and then run `./main` instead of invoking `gleam run` directly; `main` is now ignored in `.gitignore`.
> 
> Updates solution code/examples to read input via an Erlang `@external` binding to `io:get_line/1` (replacing `gleam/erlang.get_line` usage), and adds a new `dockerfiles/gleam-1.16.Dockerfile` to support the updated buildpack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86a765d13b931c7165f39b7eeb63cc708e74516e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->