### PR TITLE
Update Zig 0.16 Dockerfile to add libncurses-dev and libreadline-dev

### DIFF
--- a/dockerfiles/zig-0.16.Dockerfile
+++ b/dockerfiles/zig-0.16.Dockerfile
@@ -6,8 +6,10 @@ FROM debian:trixie
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
         curl \
-        xz-utils \
+        libncurses-dev \
+        libreadline-dev \
         procps \
+        xz-utils \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adds two Debian build dependencies to the Zig 0.16 Docker image; main impact is slightly larger image and potential package-version-related build differences.
> 
> **Overview**
> Updates `dockerfiles/zig-0.16.Dockerfile` to install `libncurses-dev` and `libreadline-dev` alongside existing packages, ensuring Zig builds that rely on ncurses/readline headers can compile in the image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d116b20289e39457b04816450f8ce055b180865a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->