### PR TITLE
Remove procps from Zig 0.16 Dockerfile to streamline dependencies

### DIFF
--- a/dockerfiles/zig-0.16.Dockerfile
+++ b/dockerfiles/zig-0.16.Dockerfile
@@ -1,14 +1,12 @@
 # syntax=docker/dockerfile:1.7-labs
 FROM debian:trixie
 
-# procps: shell / background-jobs
 # hadolint ignore=DL3008
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
         curl \
         libncurses-dev \
         libreadline-dev \
-        procps \
         xz-utils \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Superseded by a more proper fix: https://github.com/codecrafters-io/shell-tester/pull/291

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change to a build image with no application or security logic touched.
> 
> **Overview**
> The **Zig 0.16** Debian image no longer installs **`procps`** via `apt-get`, and the inline comment that tied **`procps`** to shell/background-jobs was removed. The rest of the Dockerfile (Zig download, `compile.sh`, cache layout) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93bdfba0a6c0af19cb16657b3958804c7aa8517a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->