### PR TITLE
Update Kotlin starter and solution scripts to include JVM options

### DIFF
--- a/compiled_starters/kotlin/.codecrafters/run.sh
+++ b/compiled_starters/kotlin/.codecrafters/run.sh
@@ -11,5 +11,6 @@ set -e # Exit on failure
 LIBS_DIR="/tmp/codecrafters-libs-shell-kotlin"
 BUILD_DIR="/tmp/codecrafters-build-shell-kotlin"
 KOTLIN_MAIN="$BUILD_DIR/classes/kotlin/main"
+JVM_OPTS="--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow"
 
-exec java -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"
+exec java $JVM_OPTS -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"

--- a/compiled_starters/kotlin/your_program.sh
+++ b/compiled_starters/kotlin/your_program.sh
@@ -39,4 +39,5 @@ set -e # Exit early if any commands fail
 LIBS_DIR="/tmp/codecrafters-libs-shell-kotlin"
 BUILD_DIR="/tmp/codecrafters-build-shell-kotlin"
 KOTLIN_MAIN="$BUILD_DIR/classes/kotlin/main"
-exec java -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"
+JVM_OPTS="--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow"
+exec java $JVM_OPTS -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"

--- a/solutions/kotlin/01-oo8/code/.codecrafters/run.sh
+++ b/solutions/kotlin/01-oo8/code/.codecrafters/run.sh
@@ -11,5 +11,6 @@ set -e # Exit on failure
 LIBS_DIR="/tmp/codecrafters-libs-shell-kotlin"
 BUILD_DIR="/tmp/codecrafters-build-shell-kotlin"
 KOTLIN_MAIN="$BUILD_DIR/classes/kotlin/main"
+JVM_OPTS="--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow"
 
-exec java -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"
+exec java $JVM_OPTS -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"

--- a/solutions/kotlin/01-oo8/code/your_program.sh
+++ b/solutions/kotlin/01-oo8/code/your_program.sh
@@ -39,4 +39,5 @@ set -e # Exit early if any commands fail
 LIBS_DIR="/tmp/codecrafters-libs-shell-kotlin"
 BUILD_DIR="/tmp/codecrafters-build-shell-kotlin"
 KOTLIN_MAIN="$BUILD_DIR/classes/kotlin/main"
-exec java -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"
+JVM_OPTS="--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow"
+exec java $JVM_OPTS -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"

--- a/solutions/kotlin/02-cz2/code/.codecrafters/run.sh
+++ b/solutions/kotlin/02-cz2/code/.codecrafters/run.sh
@@ -11,5 +11,6 @@ set -e # Exit on failure
 LIBS_DIR="/tmp/codecrafters-libs-shell-kotlin"
 BUILD_DIR="/tmp/codecrafters-build-shell-kotlin"
 KOTLIN_MAIN="$BUILD_DIR/classes/kotlin/main"
+JVM_OPTS="--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow"
 
-exec java -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"
+exec java $JVM_OPTS -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"

--- a/solutions/kotlin/02-cz2/code/your_program.sh
+++ b/solutions/kotlin/02-cz2/code/your_program.sh
@@ -39,4 +39,5 @@ set -e # Exit early if any commands fail
 LIBS_DIR="/tmp/codecrafters-libs-shell-kotlin"
 BUILD_DIR="/tmp/codecrafters-build-shell-kotlin"
 KOTLIN_MAIN="$BUILD_DIR/classes/kotlin/main"
-exec java -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"
+JVM_OPTS="--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow"
+exec java $JVM_OPTS -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"

--- a/solutions/kotlin/03-ff0/code/.codecrafters/run.sh
+++ b/solutions/kotlin/03-ff0/code/.codecrafters/run.sh
@@ -11,5 +11,6 @@ set -e # Exit on failure
 LIBS_DIR="/tmp/codecrafters-libs-shell-kotlin"
 BUILD_DIR="/tmp/codecrafters-build-shell-kotlin"
 KOTLIN_MAIN="$BUILD_DIR/classes/kotlin/main"
+JVM_OPTS="--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow"
 
-exec java -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"
+exec java $JVM_OPTS -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"

--- a/solutions/kotlin/03-ff0/code/your_program.sh
+++ b/solutions/kotlin/03-ff0/code/your_program.sh
@@ -39,4 +39,5 @@ set -e # Exit early if any commands fail
 LIBS_DIR="/tmp/codecrafters-libs-shell-kotlin"
 BUILD_DIR="/tmp/codecrafters-build-shell-kotlin"
 KOTLIN_MAIN="$BUILD_DIR/classes/kotlin/main"
-exec java -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"
+JVM_OPTS="--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow"
+exec java $JVM_OPTS -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"

--- a/solutions/kotlin/04-pn5/code/.codecrafters/run.sh
+++ b/solutions/kotlin/04-pn5/code/.codecrafters/run.sh
@@ -11,5 +11,6 @@ set -e # Exit on failure
 LIBS_DIR="/tmp/codecrafters-libs-shell-kotlin"
 BUILD_DIR="/tmp/codecrafters-build-shell-kotlin"
 KOTLIN_MAIN="$BUILD_DIR/classes/kotlin/main"
+JVM_OPTS="--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow"
 
-exec java -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"
+exec java $JVM_OPTS -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"

--- a/solutions/kotlin/04-pn5/code/your_program.sh
+++ b/solutions/kotlin/04-pn5/code/your_program.sh
@@ -39,4 +39,5 @@ set -e # Exit early if any commands fail
 LIBS_DIR="/tmp/codecrafters-libs-shell-kotlin"
 BUILD_DIR="/tmp/codecrafters-build-shell-kotlin"
 KOTLIN_MAIN="$BUILD_DIR/classes/kotlin/main"
-exec java -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"
+JVM_OPTS="--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow"
+exec java $JVM_OPTS -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"

--- a/solutions/kotlin/05-iz3/code/.codecrafters/run.sh
+++ b/solutions/kotlin/05-iz3/code/.codecrafters/run.sh
@@ -11,5 +11,6 @@ set -e # Exit on failure
 LIBS_DIR="/tmp/codecrafters-libs-shell-kotlin"
 BUILD_DIR="/tmp/codecrafters-build-shell-kotlin"
 KOTLIN_MAIN="$BUILD_DIR/classes/kotlin/main"
+JVM_OPTS="--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow"
 
-exec java -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"
+exec java $JVM_OPTS -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"

--- a/solutions/kotlin/05-iz3/code/your_program.sh
+++ b/solutions/kotlin/05-iz3/code/your_program.sh
@@ -39,4 +39,5 @@ set -e # Exit early if any commands fail
 LIBS_DIR="/tmp/codecrafters-libs-shell-kotlin"
 BUILD_DIR="/tmp/codecrafters-build-shell-kotlin"
 KOTLIN_MAIN="$BUILD_DIR/classes/kotlin/main"
-exec java -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"
+JVM_OPTS="--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow"
+exec java $JVM_OPTS -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"

--- a/starter_templates/kotlin/code/.codecrafters/run.sh
+++ b/starter_templates/kotlin/code/.codecrafters/run.sh
@@ -11,5 +11,6 @@ set -e # Exit on failure
 LIBS_DIR="/tmp/codecrafters-libs-shell-kotlin"
 BUILD_DIR="/tmp/codecrafters-build-shell-kotlin"
 KOTLIN_MAIN="$BUILD_DIR/classes/kotlin/main"
+JVM_OPTS="--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow"
 
-exec java -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"
+exec java $JVM_OPTS -cp "$KOTLIN_MAIN:$LIBS_DIR/*" AppKt "$@"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Shell-only launcher tweaks for JDK compatibility; no application logic or security-sensitive code paths change.
> 
> **Overview**
> Kotlin **run** entrypoints now pass JVM flags when starting `AppKt`, instead of invoking plain `java -cp ...`.
> 
> A shared `JVM_OPTS` value (`--enable-native-access=ALL-UNNAMED` and `--sun-misc-unsafe-memory-access=allow`) is wired into `.codecrafters/run.sh` and the local `your_program.sh` run block across the Kotlin starter template, compiled starters, and each solution stage copy. Behavior is unchanged aside from opting into native access and relaxed `sun.misc.Unsafe` memory warnings on newer JDKs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5c549bfb7550293510f98e4bd136796ebbac0c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->