### PR TITLE
CC-2278: Upgrade Java to v26

### DIFF
--- a/compiled_starters/java/codecrafters.yml
+++ b/compiled_starters/java/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Java version used to run your code
 # on Codecrafters.
 #
-# Available versions: java-25
-buildpack: java-25
+# Available versions: java-26
+buildpack: java-26

--- a/compiled_starters/java/pom.xml
+++ b/compiled_starters/java/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0</version>
 
    <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>25</java.version>
+        <java.version>26</java.version>
     </properties>
 
     <build>

--- a/dockerfiles/java-26.Dockerfile
+++ b/dockerfiles/java-26.Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM maven:3.9.16-eclipse-temurin-26-alpine
+
+# Ensures the container is re-built if dependency files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="pom.xml"
+ENV MAVEN_OPTS="--sun-misc-unsafe-memory-access=allow"
+
+RUN apk add --no-cache --upgrade 'bash>=5.2'
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# Install language-specific dependencies
+RUN .codecrafters/compile.sh

--- a/solutions/java/01-oo8/code/codecrafters.yml
+++ b/solutions/java/01-oo8/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Java version used to run your code
 # on Codecrafters.
 #
-# Available versions: java-25
-buildpack: java-25
+# Available versions: java-26
+buildpack: java-26

--- a/solutions/java/01-oo8/code/pom.xml
+++ b/solutions/java/01-oo8/code/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0</version>
 
    <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>25</java.version>
+        <java.version>26</java.version>
     </properties>
 
     <build>

--- a/solutions/java/02-cz2/code/codecrafters.yml
+++ b/solutions/java/02-cz2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Java version used to run your code
 # on Codecrafters.
 #
-# Available versions: java-25
-buildpack: java-25
+# Available versions: java-26
+buildpack: java-26

--- a/solutions/java/02-cz2/code/pom.xml
+++ b/solutions/java/02-cz2/code/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0</version>
 
    <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>25</java.version>
+        <java.version>26</java.version>
     </properties>
 
     <build>

--- a/solutions/java/03-ff0/code/codecrafters.yml
+++ b/solutions/java/03-ff0/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Java version used to run your code
 # on Codecrafters.
 #
-# Available versions: java-25
-buildpack: java-25
+# Available versions: java-26
+buildpack: java-26

--- a/solutions/java/03-ff0/code/pom.xml
+++ b/solutions/java/03-ff0/code/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0</version>
 
    <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>25</java.version>
+        <java.version>26</java.version>
     </properties>
 
     <build>

--- a/solutions/java/04-pn5/code/codecrafters.yml
+++ b/solutions/java/04-pn5/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Java version used to run your code
 # on Codecrafters.
 #
-# Available versions: java-25
-buildpack: java-25
+# Available versions: java-26
+buildpack: java-26

--- a/solutions/java/04-pn5/code/pom.xml
+++ b/solutions/java/04-pn5/code/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0</version>
 
    <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>25</java.version>
+        <java.version>26</java.version>
     </properties>
 
     <build>

--- a/solutions/java/05-iz3/code/codecrafters.yml
+++ b/solutions/java/05-iz3/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Java version used to run your code
 # on Codecrafters.
 #
-# Available versions: java-25
-buildpack: java-25
+# Available versions: java-26
+buildpack: java-26

--- a/solutions/java/05-iz3/code/pom.xml
+++ b/solutions/java/05-iz3/code/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0</version>
 
    <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>25</java.version>
+        <java.version>26</java.version>
     </properties>
 
     <build>

--- a/starter_templates/java/code/pom.xml
+++ b/starter_templates/java/code/pom.xml
@@ -9,10 +9,10 @@
     <version>1.0</version>
 
    <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>25</java.version>
+        <java.version>26</java.version>
     </properties>
 
     <build>


### PR DESCRIPTION
- Changed buildpack version from java-25 to java-26 in codecrafters.yml files.
- Updated Maven compiler source and target versions from 25 to 26 in pom.xml files across multiple solutions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes to build config and Docker images with no application or security logic touched; main risk is CI/runtime breakage if Java 26 images or preview flags misbehave.
> 
> **Overview**
> **Upgrades Codecrafters Java track from 25 to 26** across compiled starters, solution repos, and the Java starter template.
> 
> `codecrafters.yml` now sets **`buildpack: java-26`** (and updates the “available versions” comment). Matching **`pom.xml`** changes bump **`maven.compiler.source` / `target`** and **`java.version`** from 25 to 26; preview flags are unchanged.
> 
> Adds **`dockerfiles/java-26.Dockerfile`** on **`maven:3.9.16-eclipse-temurin-26-alpine`**, with the same Maven compile flow as the Java 25 image plus an **`bash`** apk install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e91d4086811c26858da9ca0dad0bd00eb4438a43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->