### PR TITLE
CC-2280: Tweak instructions in #fy4 to match Bash behavior

### DIFF
--- a/stage_descriptions/background-jobs-09-fy4.md
+++ b/stage_descriptions/background-jobs-09-fy4.md
@@ -5,11 +5,9 @@ In this stage, you'll implement recycling job number indices.
 Job numbers are assigned sequentially: `1`, `2`, `3`, and so on. When jobs are completed and removed from the table, the next new job reuses the smallest available number. So the next job number depends on how many jobs are still in the table:
 
 - When all jobs have completed, and the table is empty, the next job gets `[1]`.
-- If some jobs remain, the next job gets the smallest available number.
+- If some jobs remain, the next job gets the next sequential number.
 
-For example, if you have jobs `[1]` and `[3]` running, the next job gets `[2]`, not `[4]`.
-
-Here are some more examples: 
+Here are some examples:
 
 ```bash
 # Recycling to 1 when the table is empty

--- a/stage_descriptions/background-jobs-09-fy4.md
+++ b/stage_descriptions/background-jobs-09-fy4.md
@@ -2,7 +2,7 @@ In this stage, you'll implement recycling job number indices.
 
 ### Recycling Job Numbers
 
-Job numbers are normally assigned sequentially: `1`, `2`, `3`, and so on.. However, when jobs finish, they are removed from the job table, allowing job numbers to be reused.
+Normally, job numbers are assigned sequentially: `1`, `2`, `3`, and so on. However, when jobs finish, they are removed from the job table, allowing job numbers to be reused.
 
 When assigning a new job number:
 
@@ -65,7 +65,7 @@ $ jobs
 [1]+  Running                 sleep 100 &
 ```
 
-The tester will also restart your program and verify number reuse when a gap exists:
+The tester will also restart your program and verify number reuse when a job exits:
 ```bash
 $ sleep 100 &
 [1] <pid>
@@ -93,5 +93,4 @@ The tester will verify that:
 ### Notes
 
 - Job numbers are recycled—they don't grow forever. After job 2 exits, the next job is `[2]`, not `[3]`.
-- Always assign the smallest available number, not just the next sequential number.
 - When the job table is empty, reset to `[1]`.

--- a/stage_descriptions/background-jobs-09-fy4.md
+++ b/stage_descriptions/background-jobs-09-fy4.md
@@ -2,10 +2,12 @@ In this stage, you'll implement recycling job number indices.
 
 ### Recycling Job Numbers
 
-Job numbers are assigned sequentially: `1`, `2`, `3`, and so on. When jobs are completed and removed from the table, the next new job reuses the smallest available number. So the next job number depends on how many jobs are still in the table:
+Job numbers are normally assigned sequentially: `1`, `2`, `3`, and so on.. However, when jobs finish, they are removed from the job table, allowing job numbers to be reused.
 
-- When all jobs have completed, and the table is empty, the next job gets `[1]`.
-- If some jobs remain, the next job gets the next sequential number.
+When assigning a new job number:
+
+- If the job table is empty, assign `[1]`.
+- Otherwise, assign one more than the highest job number currently in the table.
 
 Here are some examples:
 


### PR DESCRIPTION
Context:

https://forum.codecrafters.io/t/bug-report-on-tester-for-fy4-incorrect-logic-passed-the-test/16165

Discussion:

https://codecrafters-io.slack.com/archives/C07H9EY1Z6X/p1781667030487769

Eddie:
> I think we can remove that sentence
> > For example, if you have jobs [1] and [3] running, the next job gets [2], not [4].


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only stage description changes with no runtime, tester, or implementation impact.
> 
> **Overview**
> Updates the **fy4** stage write-up so job-number assignment matches **Bash**, addressing learner confusion where the old text implied filling gaps (e.g. jobs `[1]` and `[3]` → next `[2]`).
> 
> The assignment rule is now explicit: **empty table → `[1]`**, otherwise **`max existing job number + 1`**. Wording is tightened in the intro, examples header, and tester section (e.g. “when a job exits” instead of “when a gap exists”). The note to **always pick the smallest available number** is removed because it contradicted Bash and the examples still in the doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04834dd56436644fcbc592c361cf7297d7437bc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->