### PR TITLE
CC-2281: Upgrade Rust to v1.96

### DIFF
--- a/compiled_starters/rust/Cargo.toml
+++ b/compiled_starters/rust/Cargo.toml
@@ -3,7 +3,7 @@ name = "codecrafters-shell"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 
 [dependencies]
 anyhow = "1.0.68"                                # error handling

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -27,7 +27,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.95)` installed locally
+1. Ensure you have `cargo (1.96)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/compiled_starters/rust/codecrafters.yml
+++ b/compiled_starters/rust/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.95
-buildpack: rust-1.95
+# Available versions: rust-1.96
+buildpack: rust-1.96

--- a/dockerfiles/rust-1.96.Dockerfile
+++ b/dockerfiles/rust-1.96.Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM rust:1.96-trixie
+
+# Rebuild the container if these files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Cargo.toml,Cargo.lock"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs cargo build
+RUN .codecrafters/compile.sh

--- a/solutions/rust/01-oo8/code/Cargo.toml
+++ b/solutions/rust/01-oo8/code/Cargo.toml
@@ -3,7 +3,7 @@ name = "codecrafters-shell"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 
 [dependencies]
 anyhow = "1.0.68"                                # error handling

--- a/solutions/rust/01-oo8/code/README.md
+++ b/solutions/rust/01-oo8/code/README.md
@@ -27,7 +27,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.95)` installed locally
+1. Ensure you have `cargo (1.96)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/01-oo8/code/codecrafters.yml
+++ b/solutions/rust/01-oo8/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.95
-buildpack: rust-1.95
+# Available versions: rust-1.96
+buildpack: rust-1.96

--- a/solutions/rust/02-cz2/code/Cargo.toml
+++ b/solutions/rust/02-cz2/code/Cargo.toml
@@ -3,7 +3,7 @@ name = "codecrafters-shell"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 
 [dependencies]
 anyhow = "1.0.68"                                # error handling

--- a/solutions/rust/02-cz2/code/README.md
+++ b/solutions/rust/02-cz2/code/README.md
@@ -27,7 +27,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.95)` installed locally
+1. Ensure you have `cargo (1.96)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/02-cz2/code/codecrafters.yml
+++ b/solutions/rust/02-cz2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.95
-buildpack: rust-1.95
+# Available versions: rust-1.96
+buildpack: rust-1.96

--- a/solutions/rust/03-ff0/code/Cargo.toml
+++ b/solutions/rust/03-ff0/code/Cargo.toml
@@ -3,7 +3,7 @@ name = "codecrafters-shell"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 
 [dependencies]
 anyhow = "1.0.68"                                # error handling

--- a/solutions/rust/03-ff0/code/README.md
+++ b/solutions/rust/03-ff0/code/README.md
@@ -27,7 +27,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.95)` installed locally
+1. Ensure you have `cargo (1.96)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/03-ff0/code/codecrafters.yml
+++ b/solutions/rust/03-ff0/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.95
-buildpack: rust-1.95
+# Available versions: rust-1.96
+buildpack: rust-1.96

--- a/solutions/rust/04-pn5/code/Cargo.toml
+++ b/solutions/rust/04-pn5/code/Cargo.toml
@@ -3,7 +3,7 @@ name = "codecrafters-shell"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 
 [dependencies]
 anyhow = "1.0.68"                                # error handling

--- a/solutions/rust/04-pn5/code/README.md
+++ b/solutions/rust/04-pn5/code/README.md
@@ -27,7 +27,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.95)` installed locally
+1. Ensure you have `cargo (1.96)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/04-pn5/code/codecrafters.yml
+++ b/solutions/rust/04-pn5/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.95
-buildpack: rust-1.95
+# Available versions: rust-1.96
+buildpack: rust-1.96

--- a/solutions/rust/05-iz3/code/Cargo.toml
+++ b/solutions/rust/05-iz3/code/Cargo.toml
@@ -3,7 +3,7 @@ name = "codecrafters-shell"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 
 [dependencies]
 anyhow = "1.0.68"                                # error handling

--- a/solutions/rust/05-iz3/code/README.md
+++ b/solutions/rust/05-iz3/code/README.md
@@ -27,7 +27,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.95)` installed locally
+1. Ensure you have `cargo (1.96)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/05-iz3/code/codecrafters.yml
+++ b/solutions/rust/05-iz3/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.95
-buildpack: rust-1.95
+# Available versions: rust-1.96
+buildpack: rust-1.96

--- a/starter_templates/rust/code/Cargo.toml
+++ b/starter_templates/rust/code/Cargo.toml
@@ -3,7 +3,7 @@ name = "codecrafters-shell"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 
 [dependencies]
 anyhow = "1.0.68"                                # error handling

--- a/starter_templates/rust/config.yml
+++ b/starter_templates/rust/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: cargo (1.95)
+  required_executable: cargo (1.96)
   user_editable_file: src/main.rs


### PR DESCRIPTION
- Updated `rust-version` in `Cargo.toml` files for starters and solutions.
- Changed `buildpack` version in `codecrafters.yml` files to reflect the new Rust version.
- Updated README files to instruct users to install `cargo (1.96)` instead of `1.95`.
- Modified `config.yml` to require `cargo (1.96)`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-pin and infrastructure-only updates with no runtime or business-logic code changes; main risk is learners or CI still on 1.95 until they upgrade locally.
> 
> **Overview**
> Bumps the CodeCrafters Rust shell track from **1.95** to **1.96** across compiled starters, starter templates, and stage solution copies.
> 
> **`rust-version`** in `Cargo.toml`, **`buildpack: rust-1.96`** (and comments) in `codecrafters.yml`, and README guidance now require **`cargo (1.96)`**. **`starter_templates/rust/config.yml`** updates the required executable the same way.
> 
> Adds **`dockerfiles/rust-1.96.Dockerfile`** (`rust:1.96-trixie`, same compile flow as the prior 1.95 image) so remote builds use the new toolchain. No application Rust source changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d1b6a48d0e9fdc55e753cead785d32c767620ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->